### PR TITLE
Support groups/accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # amplitude_flutter
+
 A Flutter plugin for tracking events to [Amplitude](https://www.amplitude.com).
 
 ## Usage
@@ -30,6 +31,16 @@ Future<void> example() async {
     ..unset('demo_user');
 
   await analytics.identify(identify);
+
+  // Amplitude Accounts [https://amplitude.zendesk.com/hc/en-us/articles/115001765532-Accounts] methods:
+  // add a user to a group
+  analytics.setGroup('orgId', 15);
+
+  // change properties of a group
+  analytics.groupIdentify('orgId', 15, Identify()..set('account_manager', 456));
+
+  // emit an event associated with a group
+  analytics.logEvent('Demo Released', properties: { 'groups': { 'orgId': 15 } });
 }
 ```
 

--- a/lib/src/amplitude_flutter.dart
+++ b/lib/src/amplitude_flutter.dart
@@ -37,12 +37,23 @@ class AmplitudeFlutter {
     buffer.add(event);
   }
 
-  Future<void> identify(Identify identify) async {
+  Future<void> identify(Identify identify,
+      {Map<String, dynamic> properties = const <String, dynamic>{}}) async {
     return logEvent(
         name: r'$identify',
-        properties: <String, dynamic>{'user_properties': identify.payload});
+        properties: <String, dynamic>{'user_properties': identify.payload}
+          ..addAll(properties));
   }
 
+  /// Adds the current user to a group
+  Future<void> setGroup(String groupType, dynamic groupValue) async {
+    return identify(Identify()..set(groupType, groupValue),
+        properties: <String, dynamic>{
+          'groups': <String, dynamic>{groupType: groupValue}
+        });
+  }
+
+  /// Sets properties on a group
   Future<void> groupIdentify(
       String groupType, dynamic groupValue, Identify identify) async {
     return logEvent(name: r'$groupidentify', properties: <String, dynamic>{

--- a/lib/src/amplitude_flutter.dart
+++ b/lib/src/amplitude_flutter.dart
@@ -38,7 +38,9 @@ class AmplitudeFlutter {
   }
 
   Future<void> identify(Identify identify) async {
-    logEvent(name: r'$identify', properties: identify.payload);
+    return logEvent(
+        name: r'$identify',
+        properties: <String, dynamic>{'user_properties': identify.payload});
   }
 
   Future<void> flushEvents() => buffer.flush();

--- a/lib/src/amplitude_flutter.dart
+++ b/lib/src/amplitude_flutter.dart
@@ -34,7 +34,7 @@ class AmplitudeFlutter {
         Event(name, sessionId: session.getSessionId(), props: properties)
           ..addProps(deviceInfo.get());
 
-    buffer.add(event);
+    return buffer.add(event);
   }
 
   Future<void> identify(Identify identify,

--- a/lib/src/amplitude_flutter.dart
+++ b/lib/src/amplitude_flutter.dart
@@ -43,6 +43,14 @@ class AmplitudeFlutter {
         properties: <String, dynamic>{'user_properties': identify.payload});
   }
 
+  Future<void> groupIdentify(
+      String groupType, dynamic groupValue, Identify identify) async {
+    return logEvent(name: r'$groupidentify', properties: <String, dynamic>{
+      'group_properties': identify.payload,
+      'groups': <String, dynamic>{groupType: groupValue}
+    });
+  }
+
   Future<void> flushEvents() => buffer.flush();
 
   void _init() {

--- a/lib/src/identify.dart
+++ b/lib/src/identify.dart
@@ -2,12 +2,7 @@ import 'package:flutter/foundation.dart';
 
 class Identify {
   Identify() {
-    userProps = <String, dynamic>{};
-
-    payload = <String, dynamic>{
-      'event_type': r'$identify',
-      'user_properties': userProps
-    };
+    payload = <String, dynamic>{};
   }
 
   static const String OP_SET = r'$set';
@@ -17,7 +12,6 @@ class Identify {
   static const String OP_UNSET = r'$unset';
 
   Map<String, dynamic> payload;
-  Map<String, dynamic> userProps;
 
   void set(String key, dynamic value) {
     addOp(OP_SET, key, value);
@@ -47,6 +41,6 @@ class Identify {
   }
 
   Map<String, dynamic> _opMap(String key) {
-    return userProps.putIfAbsent(key, () => <String, dynamic>{});
+    return payload.putIfAbsent(key, () => <String, dynamic>{});
   }
 }

--- a/test/amplitude_flutter_test.dart
+++ b/test/amplitude_flutter_test.dart
@@ -61,6 +61,25 @@ void main() {
         }));
   });
 
+  test('groupIdentify', () async {
+    amplitude
+      ..groupIdentify('orgId', 15, Identify()..set('num employees', '1000+'))
+      ..flushEvents();
+
+    expect(
+        client.postCalls.single.single,
+        ContainsSubMap(<String, dynamic>{
+          'event_type': r'$groupidentify',
+          'session_id': '123',
+          'group_properties': {
+            r'$set': {'num employees': '1000+'}
+          },
+          'groups': {'orgId': 15},
+          'platform': 'iOS',
+          'timestamp': isInstanceOf<int>()
+        }));
+  });
+
   group('with properties', () {
     test('logEvent', () async {
       final Map<String, Map<String, String>> properties =

--- a/test/amplitude_flutter_test.dart
+++ b/test/amplitude_flutter_test.dart
@@ -62,9 +62,9 @@ void main() {
   });
 
   test('groupIdentify', () async {
-    amplitude
-      ..groupIdentify('orgId', 15, Identify()..set('num employees', '1000+'))
-      ..flushEvents();
+    await amplitude.groupIdentify(
+        'orgId', 15, Identify()..set('num employees', '1000+'));
+    await amplitude.flushEvents();
 
     expect(
         client.postCalls.single.single,
@@ -81,9 +81,8 @@ void main() {
   });
 
   test('setGroup', () async {
-    amplitude
-      ..setGroup('orgId', 15)
-      ..flushEvents();
+    await amplitude.setGroup('orgId', 15);
+    await amplitude.flushEvents();
 
     expect(
         client.postCalls.single.single,

--- a/test/amplitude_flutter_test.dart
+++ b/test/amplitude_flutter_test.dart
@@ -80,6 +80,25 @@ void main() {
         }));
   });
 
+  test('setGroup', () async {
+    amplitude
+      ..setGroup('orgId', 15)
+      ..flushEvents();
+
+    expect(
+        client.postCalls.single.single,
+        ContainsSubMap(<String, dynamic>{
+          'event_type': r'$identify',
+          'session_id': '123',
+          'user_properties': {
+            r'$set': {'orgId': 15}
+          },
+          'groups': {'orgId': 15},
+          'platform': 'iOS',
+          'timestamp': isInstanceOf<int>()
+        }));
+  });
+
   group('with properties', () {
     test('logEvent', () async {
       final Map<String, Map<String, String>> properties =

--- a/test/identify_test.dart
+++ b/test/identify_test.dart
@@ -10,13 +10,8 @@ void main() {
     });
 
     group('default constructor', () {
-      test(r'sets a blank $identify payload', () {
-        expect(
-            subject.payload,
-            equals({
-              'event_type': r'$identify',
-              'user_properties': <String, dynamic>{}
-            }));
+      test('sets a blank identify payload', () {
+        expect(subject.payload, equals(<String, dynamic>{}));
       });
     });
 
@@ -27,10 +22,7 @@ void main() {
             subject.payload,
             equals(
               {
-                'event_type': r'$identify',
-                'user_properties': {
-                  r'$set': {'cohort': 'Test A'}
-                }
+                r'$set': {'cohort': 'Test A'}
               },
             ));
       });
@@ -41,10 +33,7 @@ void main() {
             subject.payload,
             equals(
               {
-                'event_type': r'$identify',
-                'user_properties': {
-                  r'$setOnce': {'cohort': 'Test A'}
-                }
+                r'$setOnce': {'cohort': 'Test A'}
               },
             ));
       });
@@ -55,10 +44,7 @@ void main() {
             subject.payload,
             equals(
               {
-                'event_type': r'$identify',
-                'user_properties': {
-                  r'$add': {'login_count': 1}
-                }
+                r'$add': {'login_count': 1}
               },
             ));
       });
@@ -69,10 +55,7 @@ void main() {
             subject.payload,
             equals(
               {
-                'event_type': r'$identify',
-                'user_properties': {
-                  r'$append': {'tags': 'new tag'}
-                }
+                r'$append': {'tags': 'new tag'}
               },
             ));
       });
@@ -83,10 +66,7 @@ void main() {
             subject.payload,
             equals(
               {
-                'event_type': r'$identify',
-                'user_properties': {
-                  r'$unset': {'demo_user': '-'}
-                }
+                r'$unset': {'demo_user': '-'}
               },
             ));
       });
@@ -103,14 +83,11 @@ void main() {
             subject.payload,
             equals(
               {
-                'event_type': r'$identify',
-                'user_properties': {
-                  r'$set': {'cohort': 'Test A'},
-                  r'$setOnce': {'completed_onboarding': 'true'},
-                  r'$add': {'login_count': 1},
-                  r'$unset': {'demo_user': '-'},
-                  r'$append': {'tags': 'new tag'},
-                }
+                r'$set': {'cohort': 'Test A'},
+                r'$setOnce': {'completed_onboarding': 'true'},
+                r'$add': {'login_count': 1},
+                r'$unset': {'demo_user': '-'},
+                r'$append': {'tags': 'new tag'},
               },
             ));
       });
@@ -121,7 +98,7 @@ void main() {
 
       test(r'adds an user property operation', () {
         subject.addOp(op, 'cohort', 'Test A');
-        expect(subject.userProps, containsPair(op, {'cohort': 'Test A'}));
+        expect(subject.payload, containsPair(op, {'cohort': 'Test A'}));
       });
 
       test(r'adds multiple properties for an operation', () {
@@ -130,7 +107,7 @@ void main() {
           ..addOp(op, 'interests', ['chess', 'football']);
 
         expect(
-            subject.userProps,
+            subject.payload,
             containsPair(op, {
               'cohort': 'Test A',
               'interests': ['chess', 'football']
@@ -140,7 +117,7 @@ void main() {
       test(r'overwrites entries with the same key for a given operation', () {
         subject..addOp(op, 'cohort', 'Test A')..addOp(op, 'cohort', 'Test B');
 
-        expect(subject.userProps, containsPair(op, {'cohort': 'Test B'}));
+        expect(subject.payload, containsPair(op, {'cohort': 'Test B'}));
       });
     });
   });


### PR DESCRIPTION
## Summary
- Support setting groups with the `.setGroup()` call
- Support `$groupidentify` event with `.groupIdentify()`
- Document emitting events associated with a group