### PR TITLE
Features/batch size retry

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -2,6 +2,8 @@ import 'dart:convert';
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:http/http.dart' as http;
 
+import 'time_utils.dart';
+
 class Client {
   factory Client(String apiKey) {
     if (_instance != null) {
@@ -15,13 +17,12 @@ class Client {
 
   static const String apiUrl = 'https://api.amplitude.com/';
   static const String apiVersion = '2';
-  static const int OK = 200;
   static Client _instance;
 
   final String apiKey;
 
-  Future<bool> post(List<Map<String, dynamic>> eventData) async {
-    final String uploadTime = DateTime.now().millisecondsSinceEpoch.toString();
+  Future<int> post(List<Map<String, dynamic>> eventData) async {
+    final String uploadTime = TimeUtils().currentTime().toString();
     final String events = json.encode(eventData);
     final String checksum = apiVersion + apiKey + events + uploadTime;
     final String md5 = crypto.md5.convert(utf8.encode(checksum)).toString();
@@ -34,9 +35,9 @@ class Client {
         'upload_time': uploadTime,
         'checksum': md5
       });
-      return response.statusCode == OK;
+      return response.statusCode;
     } catch (e) {
-      return false;
+      return 500;
     }
   }
 }

--- a/test/event_buffer_test.dart
+++ b/test/event_buffer_test.dart
@@ -114,28 +114,51 @@ void main() {
         provider = MockServiceProvider(client: mockClient, store: mockStore);
         subject = EventBuffer(provider, Config());
 
-        final events = [Event('flush 1', id: 1), Event('flush 2', id: 2)];
+        final events = [
+          Event('flush 1', id: 1),
+          Event('flush 2', id: 2),
+          Event('flush 3', id: 3)
+        ];
 
         when(mockStore.length).thenReturn(events.length);
         when(mockStore.fetch(any)).thenAnswer((_) => Future.value(events));
       });
 
       test('deletes events on success', () async {
-        when(mockClient.post(any)).thenAnswer((_) => Future.value(true));
+        when(mockClient.post(any)).thenAnswer((_) => Future.value(200));
 
         await subject.flush();
 
         verify(mockClient.post(any)).called(1);
-        verify(mockStore.delete([1, 2])).called(1);
+        verify(mockStore.delete([1, 2, 3])).called(1);
       });
 
       test('does not delete events on failure', () async {
-        when(mockClient.post(any)).thenAnswer((_) => Future.value(false));
+        when(mockClient.post(any)).thenAnswer((_) => Future.value(400));
 
         await subject.flush();
 
         verify(mockClient.post(any)).called(1);
         verifyNever(mockStore.delete(any));
+      });
+
+      test('reduces num events when payload too large', () async {
+        when(mockClient.post(any)).thenAnswer((_) => Future.value(413));
+        expect(subject.numEvents, equals(null));
+
+        await subject.flush();
+
+        verify(mockClient.post(any)).called(1);
+        verifyNever(mockStore.delete(any));
+        expect(subject.numEvents, equals(1));
+        expect(subject.backoff, equals(true));
+
+        when(mockClient.post(any)).thenAnswer((_) => Future.value(200));
+
+        await subject.flush();
+        verify(mockStore.delete(any)).called(1);
+        expect(subject.numEvents, equals(null));
+        expect(subject.backoff, equals(false));
       });
     });
   });

--- a/test/mock_client.dart
+++ b/test/mock_client.dart
@@ -7,9 +7,9 @@ class MockClient implements Client {
   final List<dynamic> postCalls = <dynamic>[];
 
   @override
-  Future<bool> post(dynamic eventData) async {
+  Future<int> post(dynamic eventData) async {
     postCalls.add(eventData);
-    return Future.value(true);
+    return Future.value(200);
   }
 
   void reset() => postCalls.clear();


### PR DESCRIPTION
- send all events in the buffer unless `numEvents` is specified
- when a 413 is returned, cut the number of events by 2 and resubmit until success or there is a single event
- if the single event is too large, drop it and reset to sending all events