### PR TITLE
Send event_id instead of sequence_number

### DIFF
--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -28,9 +28,9 @@ class Event {
 
   Map<String, dynamic> toPayload() {
     return <String, dynamic>{
+      'event_id': id,
       'event_type': name,
       'session_id': sessionId,
-      'sequence_number': id,
       'timestamp': timestamp,
       'uuid': uuid,
       'library': {

--- a/test/event_test.dart
+++ b/test/event_test.dart
@@ -91,9 +91,9 @@ void main() {
         expect(
             subject.toPayload(),
             ContainsSubMap(<String, dynamic>{
+              'event_id': 99,
               'event_type': 'click',
               'session_id': '123',
-              'sequence_number': 99,
               'timestamp': 12345,
               'user_properties': {'cohort': 'test a'},
               'uuid': isNotNull,


### PR DESCRIPTION
## Summary
`sequence_number` was incorrectly being sent instead of `event_id`, with the same semantics.  They ids are unique within a session.  This PR sends the id in the correct property.
