### PR TITLE
Limit the number of events stored in the durable store

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -94,7 +94,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.3+1"
+    version: "0.12.5"
   meta:
     dependency: transitive
     description:
@@ -122,14 +122,14 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   quiver:
     dependency: transitive
     description:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -141,7 +141,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.4"
+    version: "1.5.5"
   sqflite:
     dependency: transitive
     description:
@@ -162,7 +162,7 @@ packages:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.8"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -190,7 +190,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.4"
   typed_data:
     dependency: transitive
     description:
@@ -213,5 +213,5 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.1.0 <3.0.0"
+  dart: ">=2.2.0 <3.0.0"
   flutter: ">=1.2.1 <2.0.0"

--- a/lib/src/config.dart
+++ b/lib/src/config.dart
@@ -2,15 +2,18 @@ class Config {
   Config(
       {this.sessionTimeout = defaultSessionTimeout,
       this.bufferSize = defaultBufferSize,
+      this.maxStoredEvents = defaultMaxStoredEvents,
       this.flushPeriod = defaultFlushPeriod,
       this.optOut = false});
 
   final int sessionTimeout;
   final int bufferSize;
+  final int maxStoredEvents;
   final int flushPeriod;
   final bool optOut;
 
   static const defaultSessionTimeout = 300000;
   static const defaultBufferSize = 10;
+  static const defaultMaxStoredEvents = 1000;
   static const defaultFlushPeriod = 30;
 }

--- a/lib/src/event_buffer.dart
+++ b/lib/src/event_buffer.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math';
+
 import 'package:flutter/foundation.dart';
 
 import 'client.dart';
@@ -32,6 +33,11 @@ class EventBuffer {
 
   /// Adds a raw event hash to the buffer
   Future<void> add(Event event) async {
+    if (length >= config.maxStoredEvents) {
+      print('Max stored events reached.  Discarding event.');
+      return;
+    }
+
     event.timestamp = TimeUtils().currentTime();
     await store.add(event);
 

--- a/test/event_buffer_test.dart
+++ b/test/event_buffer_test.dart
@@ -1,11 +1,10 @@
-import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
-
 import 'package:amplitude_flutter/src/client.dart';
 import 'package:amplitude_flutter/src/config.dart';
 import 'package:amplitude_flutter/src/event.dart';
 import 'package:amplitude_flutter/src/event_buffer.dart';
 import 'package:amplitude_flutter/src/store.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
 import 'matchers.dart';
 import 'mock_client.dart';
@@ -69,6 +68,20 @@ void main() {
               'timestamp': isInstanceOf<int>()
             }));
         expect(client.postCalls.single, isList);
+      });
+
+      test('limits number of events added to the store', () async {
+        // Have the client return an unhandled status code so the store doesn't get cleared
+        provider.client = MockClient(httpStatus: 218);
+        subject =
+            EventBuffer(provider, Config(bufferSize: 1, maxStoredEvents: 2));
+
+        await subject.add(Event('test 1'));
+        await subject.add(Event('test 2'));
+        expect(subject.length, equals(2));
+
+        await subject.add(Event('test 3'));
+        expect(subject.length, equals(2));
       });
     });
 

--- a/test/mock_client.dart
+++ b/test/mock_client.dart
@@ -1,15 +1,18 @@
 import 'package:amplitude_flutter/src/client.dart';
 
 class MockClient implements Client {
+  MockClient({this.httpStatus: 200});
+
   @override
   String apiKey;
+  int httpStatus;
 
   final List<dynamic> postCalls = <dynamic>[];
 
   @override
   Future<int> post(dynamic eventData) async {
     postCalls.add(eventData);
-    return Future.value(200);
+    return Future.value(httpStatus);
   }
 
   void reset() => postCalls.clear();

--- a/test/mock_store.dart
+++ b/test/mock_store.dart
@@ -1,21 +1,25 @@
-import 'package:amplitude_flutter/src/store.dart';
 import 'package:amplitude_flutter/src/event.dart';
+import 'package:amplitude_flutter/src/store.dart';
 
 class MockStore implements Store {
   @override
   int length = 0;
+  int curId = 10000;
 
   final List<Event> db = <Event>[];
 
   @override
   Future<int> add(Event event) {
+    event.id = ++curId;
     db.add(event);
     length++;
     return Future.value(0);
   }
 
   @override
-  Future<void> delete(List<int> eventIds) async {}
+  Future<void> delete(List<int> eventIds) async {
+    db.removeWhere((Event event) => eventIds.contains(event.id));
+  }
 
   @override
   Future<void> empty() async {


### PR DESCRIPTION
## Problem
In case of a misconfiguration or network issue, stored events can queue up unbounded.

## Solution
Add a `maxStoredEvents` config option, that will cap the number of stored events.  If additional events are added once this cap is reached, they will be discarded.