### PR TITLE
Allow backwards-compatible versions of package_info

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   device_info: "^0.4.0+1"
-  package_info: "0.4.0+3"
+  package_info: "^0.4.0+3"
   http: "^0.12.0+2"
   crypto: "^2.0.6"
   sqflite: "^1.1.5"


### PR DESCRIPTION
## Summary
Use caret syntax to specify version for `package_info`