### PR TITLE
Ensure DeviceInfo has fetched a device id before sending any events.

### DIFF
--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -28,6 +28,7 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
     analytics = AmplitudeFlutter(widget.apiKey, Config(bufferSize: 8));
+    analytics.logEvent(name: 'MyApp startup');
   }
 
   Future<void> _flushEvents() async {

--- a/lib/src/amplitude_flutter.dart
+++ b/lib/src/amplitude_flutter.dart
@@ -47,7 +47,7 @@ class AmplitudeFlutter {
 
     final Event event =
         Event(name, sessionId: session.getSessionId(), props: properties)
-          ..addProps(deviceInfo.get());
+          ..addProps(await deviceInfo.getPlatformInfo());
 
     if (userId != null) {
       event.addProp('user_id', userId);

--- a/lib/src/device_info.dart
+++ b/lib/src/device_info.dart
@@ -4,16 +4,8 @@ import 'package:device_info/device_info.dart';
 import 'package:package_info/package_info.dart';
 
 class DeviceInfo {
-  DeviceInfo() {
-    getPlatformInfo();
-  }
-
   static final DeviceInfoPlugin deviceInfoPlugin = DeviceInfoPlugin();
   Map<String, String> _deviceData = <String, String>{};
-
-  Map<String, String> get() {
-    return _deviceData;
-  }
 
   Future<Map<String, String>> getPlatformInfo() async {
     if (_deviceData.isNotEmpty) {

--- a/test/amplitude_flutter_test.dart
+++ b/test/amplitude_flutter_test.dart
@@ -21,8 +21,8 @@ void main() {
     deviceInfo = provider.deviceInfo;
     session = provider.session;
 
-    when(deviceInfo.get())
-        .thenAnswer((_) => <String, String>{'platform': 'iOS'});
+    when(deviceInfo.getPlatformInfo()).thenAnswer(
+        (_) => Future<Map<String, String>>.value({'platform': 'iOS'}));
     when(session.getSessionId()).thenAnswer((_) => '123');
 
     client.reset();


### PR DESCRIPTION
## Problem
There were some cases where a `user_id` and `device_id` weren't being sent with events, causing the event to be discarded at the API endpoint.  This could happen, for example, when sending an event immediately after instantiating `AmplitudeFlutter`.

## Solution
Wait for `DeviceInfo` to be available when logging events.