### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 1.2.0
 * Can track advertising Id now.
 * Will use a random UUID for device Id if ads tracking is disabled on the phone.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplitude_flutter
 description: Official Flutter plugin for tracking events and revenue to Amplitude.
-version: 1.2.0
+version: 1.2.1
 homepage: https://github.com/amplitude/Amplitude-Flutter
 
 environment:
@@ -12,7 +12,7 @@ dependencies:
   crypto: "^2.0.6"
   device_info: "^0.4.1+4"
   http: "^0.12.0+2"
-  package_info: "^0.4.0+13"
+  package_info: '>=0.4.0+13 <2.0.0'
   path: "^1.6.4"
   shared_preferences: "^0.5.6+2"
   sqflite: "^1.1.5"


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).