### PR TITLE
Expose the possibility to add custom Store

### DIFF
--- a/lib/amplitude_flutter.dart
+++ b/lib/amplitude_flutter.dart
@@ -1,6 +1,8 @@
 library amplitude_flutter;
 
 export 'src/amplitude_flutter.dart';
+export 'src/client.dart';
 export 'src/config.dart';
 export 'src/identify.dart';
 export 'src/revenue.dart';
+export 'src/service_provider.dart';

--- a/lib/amplitude_flutter.dart
+++ b/lib/amplitude_flutter.dart
@@ -6,3 +6,4 @@ export 'src/config.dart';
 export 'src/identify.dart';
 export 'src/revenue.dart';
 export 'src/service_provider.dart';
+export 'src/store.dart';

--- a/lib/src/amplitude_flutter.dart
+++ b/lib/src/amplitude_flutter.dart
@@ -21,7 +21,6 @@ class AmplitudeFlutter {
     _init();
   }
 
-  @visibleForTesting
   AmplitudeFlutter.private(this.provider, this.config) {
     _init();
   }

--- a/lib/src/service_provider.dart
+++ b/lib/src/service_provider.dart
@@ -9,11 +9,12 @@ class ServiceProvider {
   ServiceProvider(
       {@required String apiKey,
       @required int timeout,
-      @required bool getCarrierInfo}) {
+      @required bool getCarrierInfo,
+      this.store}) {
     client = Client(apiKey);
     deviceInfo = DeviceInfo(getCarrierInfo);
-    store = Store();
     session = Session(timeout);
+    store ??= Store();
   }
 
   Client client;

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -21,8 +21,8 @@ class Store {
     _init();
   }
 
-  static const Map<String, Store> _instances = {};
-  static Database _db;
+  static final Map<String, Store> _instances = {};
+  Database _db;
   final String dbFile;
   int length = 0;
 

--- a/lib/src/store.dart
+++ b/lib/src/store.dart
@@ -11,16 +11,19 @@ const String COL_EVENT_TYPE = 'event_type';
 const String COL_TIMESTAMP = 'timestamp';
 const String COL_SESSION_ID = 'session_id';
 const String COL_PROPS = 'props_json';
+const String DEFAULT_DB_NAME = 'amp.db';
 
 class Store {
-  factory Store() => _instance ??= Store._();
-  Store._() {
+  factory Store({String dbFile = DEFAULT_DB_NAME}) =>
+      _instances.putIfAbsent(dbFile, () => Store._(dbFile));
+
+  Store._(this.dbFile) {
     _init();
   }
 
-  static Store _instance;
+  static const Map<String, Store> _instances = {};
   static Database _db;
-  static const dbFile = 'amp.db';
+  final String dbFile;
   int length = 0;
 
   Future<int> add(Event event) async {

--- a/test/mock_store.dart
+++ b/test/mock_store.dart
@@ -37,4 +37,7 @@ class MockStore implements Store {
     final List<Event> popped = db.sublist(0, count);
     return Future.value(popped);
   }
+
+  @override
+  String get dbFile => 'amp.db';
 }


### PR DESCRIPTION
This PRs intends to contribute with:

1. Expose `Client`, `ServiceProvider` and `Store` to external use
2. Expose constructor which you can pass a custom `ServiceProvider`
3. Let ServiceProvider receive a custom Store (Useful for managing multiple dbs)
4. Store with named database per instance instead of a Singleton

These changes are retro-compatible and it is intended to increase usability.

This PR is related to issue #63 