### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug report 🐛
+about: You're having technical issues
+labels: 'bug'
+---
+
+<!--- Please fill out the template to the best of your ability -->
+
+## Expected Behavior
+<!--- What should have happened? -->
+
+## Current Behavior
+<!--- What went wrong? -->
+
+## Possible Solution
+<!--- (Not obligatory) Suggest a fix/reason -->
+
+## Steps to Reproduce
+<!--- Please provide a clear sequence of steps to reproduce this bug --> 
+<!--- Include code and images, if relevant -->
+1.
+2.
+3.
+4.
+
+## Environment
+- SDK Version: <!--- E.g. v2.2.0 -->
+- Flutter Version: <!-- E.g. v1.20.2 -->
+- Device: <!-- E.g. iPhone 11, Samsung Galaxy S20 -->

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -27,3 +27,4 @@ labels: 'bug'
 - SDK Version: <!--- E.g. v2.2.0 -->
 - Flutter Version: <!-- E.g. v1.20.2 -->
 - Device: <!-- E.g. iPhone 11, Samsung Galaxy S20 -->
+- Device OS and Version: <!-- E.g. iOS 13.3.1, Android 8.1.0 -->

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature Request 🚀
+about: You'd like something added to the SDK
+labels: 'feature request'
+---
+
+<!--- Please fill out the template to the best of your ability -->
+
+## Summary
+
+<!-- Please describe what feature you would like added -->
+
+## Motivations
+
+<!-- Please explain what value this feature would add. E.g. what problem does it solve -->

--- a/.github/ISSUE_TEMPLATE/Question.md
+++ b/.github/ISSUE_TEMPLATE/Question.md
@@ -1,0 +1,9 @@
+---
+name: Question ❓
+about: Ask a question
+labels: 'question'
+---
+
+## Summary
+
+<!-- What do you need help with? -->


### PR DESCRIPTION
Same as the [JS SDK issue templates](https://github.com/amplitude/Amplitude-JavaScript/tree/master/.github/ISSUE_TEMPLATE) except for the [environment asks](https://github.com/amplitude/Amplitude-Flutter/compare/github-issue-templates?expand=1#diff-ca276526c404f3a4be0d52f78b12ecbaR26)