### PR TITLE
fix: make sure userid is not set to null on startup

### DIFF
--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -34,8 +34,13 @@ import Amplitude
                         return
                     }
 
-                    let userId = args["userId"] as! String?
-                    Amplitude.instance(withName: instanceName).initializeApiKey(apiKey, userId: userId)
+                    if let userId = args["userId"] as? String {
+                        Amplitude.instance(withName: instanceName).initializeApiKey(apiKey, userId: userId)
+                    }
+                    else {
+                        Amplitude.instance(withName: instanceName).initializeApiKey(apiKey)
+                    }   
+                    
                     result(true)
 
                 // Get deviceId


### PR DESCRIPTION
The iOS native SDK actually provides 2 different init methods, opposed to android. When null is passed on initialization the userid was set to null in the amplitude dashboard, resulting in a wrong flow.