### PR TITLE
Feature: Add setMinTimeBetweenSessionsMillis to Flutter SDK

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -201,6 +201,11 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler {
 
                 result.success("uploadEvents called..")
             }
+            "setMinTimeBetweenSessionsMillis" -> {
+                val client = Amplitude.getInstance(instanceName)
+                client.setMinTimeBetweenSessionsMillis(json.getLong("timeInMillis"))
+                result.success("setMinTimeBetweenSessionsMillis called..")
+            }
             else -> {
                 result.notImplemented()
             }

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -4,14 +4,14 @@ import 'package:amplitude_flutter/amplitude.dart';
 import 'package:flutter/material.dart';
 
 import 'app_state.dart';
+import 'deviceid_sessionid.dart';
 import 'event_form.dart';
 import 'group_form.dart';
 import 'group_identify_form.dart';
 import 'identify_form.dart';
+import 'regenerate_device.dart';
 import 'revenue_form.dart';
 import 'user_id_form.dart';
-import 'regenerate_device.dart';
-import 'deviceid_sessionid.dart';
 
 class MyApp extends StatefulWidget {
   const MyApp(this.apiKey);
@@ -38,6 +38,7 @@ class _MyAppState extends State<MyApp> {
     analytics.enableCoppaControl();
     analytics.setUserId("test_user");
     analytics.trackingSessionEvents(true);
+    analytics.setMinTimeBetweenSessionsMillis(5000);
     analytics.logEvent('MyApp startup',
         eventProperties: {'event_prop_1': 10, 'event_prop_2': true});
     Map<String, dynamic> userProps = {

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -171,7 +171,11 @@ import Amplitude
                 case "uploadEvents":
                     Amplitude.instance(withName: instanceName).uploadEvents()
                     result(true)
-
+                case "setMinTimeBetweenSessionsMillis":
+                     let timeInMillis = args["timeInMillis"] as! Int
+                    Amplitude.instance(withName: instanceName).minTimeBetweenSessionsMillis = timeInMillis
+                    result(true)
+            
                 default:
                     result(FlutterMethodNotImplemented)
                 }

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -278,7 +278,8 @@ class Amplitude extends _Amplitude {
   /// Fetches the userId, a unique identifier for tracking a user.
   /// @returns the userId
   Future<String?> getUserId() async {
-    return await _channel.invokeMethod('getUserId', jsonEncode(_baseProperties()));
+    return await _channel.invokeMethod(
+        'getUserId', jsonEncode(_baseProperties()));
   }
 
   /// Fetches the current sessionId, an identifier used by Amplitude to group together events tracked during the same session.
@@ -286,5 +287,14 @@ class Amplitude extends _Amplitude {
   Future<int?> getSessionId() async {
     return await _channel.invokeMethod(
         'getSessionId', jsonEncode(_baseProperties()));
+  }
+
+  /// Defines a custom session expiration time where the timeout input is in milliseconds.
+  Future<void> setMinTimeBetweenSessionsMillis(int timeInMillis) async {
+    Map<String, dynamic> properties = _baseProperties();
+    properties['timeInMillis'] = timeInMillis;
+
+    return await _channel.invokeMethod(
+        'setMinTimeBetweenSessionsMillis', jsonEncode(properties));
   }
 }


### PR DESCRIPTION
Exposes the setMinTimeBetweenSessionsMillis from iOS and Android
to the upper Flutter SDK. This function is currently missing in the Flutter
SDK.