### PR TITLE
fix: fix setUseDynamicConfig using wrong native android api call

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -114,7 +114,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler {
             }
             "setUseDynamicConfig" -> {
                 val client = Amplitude.getInstance(instanceName)
-                client.trackSessionEvents(json.getBoolean("useDynamicConfig"))
+                client.setUseDynamicConfig(json.getBoolean("useDynamicConfig"))
 
                 result.success("setUseDynamicConfig called..")
             }


### PR DESCRIPTION
setUseDynamicConfig should call client.setUseDynamicConfig instead of trackSessionEvents.