### PR TITLE
chore: update amplitude android version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,6 @@ android {
 }
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "com.amplitude:android-sdk:2.34.0"
+    implementation "com.amplitude:android-sdk:2.37.0"
     implementation "com.squareup.okhttp3:okhttp:4.2.2"
 }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.40'
+    ext.kotlin_version = '1.6.0'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
The android app set id has been updated in amplitude-android. Adopt the newest amplitude-android in order to reflect the change in amplitude-flutter.