### PR TITLE
chore: update the kotlin gradle version for compatible with latest gradle version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ group 'com.amplitude.amplitude_flutter'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.40'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:3.6.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip


### PR DESCRIPTION
Description:

The existing gradle dependency has kotlin plugin 1.3.40 which is not compatible with the latest gradle and kotlin plugin. 
After discussion, we decided to support the latest version of gradle and recommend the customer who use lower version of the gradle to use lower version of amplitude flutter.

Upgrade versions based on https://kotlinlang.org/docs/whatsnew17.html#bumping-minimum-supported-versions

This is the related PR for the doc.
https://github.com/Amplitude-Developer-Docs/amplitude-dev-center/pull/345
