### PR TITLE
Add receipt support for revenue logging

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -161,6 +161,14 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler {
                 val revenue = Revenue().setProductId(json.getString("productIdentifier"))
                     .setPrice(json.getDouble("price"))
                     .setQuantity(json.getInt("quantity"))
+                json.optString("revenueType", null)?.let { it ->
+                    revenue.setRevenueType(it)
+                }
+                val receipt = json.optString("receipt", null)
+                val receiptSignature = json.optString("receiptSignature", null)
+                if (receipt != null && receiptSignature != null) {
+                    revenue.setReceipt(receipt, receiptSignature)
+                }
                 client.logRevenueV2(revenue)
 
                 result.success("logRevenue called..")

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,21 +28,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -63,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -92,28 +85,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -125,7 +118,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -146,21 +139,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -124,6 +124,12 @@ import Amplitude
                     revenue.setProductIdentifier((args["productIdentifier"] as! String))
                     revenue.setQuantity(args["quantity"] as! Int)
                     revenue.setPrice(NSNumber(value: args["price"] as! Double))
+                    if let revenueType = args["revenueType"] as? String {
+                        revenue.setRevenueType(revenueType)
+                    }
+                    if let receipt = args["receipt"] as? String {
+                        revenue.setReceipt(Data(base64Encoded: receipt, options: .ignoreUnknownCharacters))
+                    }
 
                     Amplitude.instance(withName: instanceName).logRevenueV2(revenue)
 

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -152,11 +152,21 @@ class Amplitude extends _Amplitude {
   /// active user (ARPDAU), 7, 30, and 90 day revenue, lifetime value (LTV)
   /// estimates, and revenue by advertising campaign cohort and daily/weekly/monthly cohorts.
   Future<void> logRevenue(
-      String productIdentifier, int quantity, double price) async {
+      String productIdentifier, int quantity, double price,
+      {String? revenueType, String? receipt, String? receiptSignature,}) async {
     Map<String, dynamic> properties = _baseProperties();
     properties['productIdentifier'] = productIdentifier;
     properties['quantity'] = quantity;
     properties['price'] = price;
+    if (revenueType != null) {
+      properties['revenueType'] = revenueType;
+    }
+    if (receipt != null) {
+      properties['receipt'] = receipt;
+    }
+    if (receiptSignature != null) {
+      properties['receiptSignature'] = receiptSignature;
+    }
 
     return await _channel.invokeMethod('logRevenue', jsonEncode(properties));
   }


### PR DESCRIPTION
Hello!

We have noted that some revenue verification parameters are missing in the current Flutter plugin, so we added a few lines to add support for that thing :)

We use Amplitude in combination with the [official in-app purchase plugin for Flutter](https://pub.dev/packages/in_app_purchase).
For iOS, we can get Base64-encoded receipt via [purchaseDetails](https://pub.dev/documentation/in_app_purchase_platform_interface/latest/in_app_purchase_platform_interface/PurchaseDetails-class.html).[verificationData](https://pub.dev/documentation/in_app_purchase_platform_interface/latest/in_app_purchase_platform_interface/PurchaseVerificationData-class.html).[serverVerificationData](https://pub.dev/documentation/in_app_purchase_platform_interface/latest/in_app_purchase_platform_interface/PurchaseVerificationData/serverVerificationData.html);

For Android, we cast purchaseDetails to [GooglePlayPurchaseDetails](https://pub.dev/documentation/in_app_purchase_android/latest/in_app_purchase_android/GooglePlayPurchaseDetails-class.html) first, and then we get receipt and signature via [billingClientPurchase](https://pub.dev/documentation/in_app_purchase_android/latest/billing_client_wrappers/PurchaseWrapper-class.html).[originalJson](https://pub.dev/documentation/in_app_purchase_android/latest/billing_client_wrappers/PurchaseWrapper/originalJson.html) and [billingClientPurchase](https://pub.dev/documentation/in_app_purchase_android/latest/billing_client_wrappers/PurchaseWrapper-class.html).[signature](https://pub.dev/documentation/in_app_purchase_android/latest/billing_client_wrappers/PurchaseWrapper/signature.html) respectively.