### PR TITLE
Expose "setOffline" method

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -244,6 +244,13 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler {
                 result.success("setServerZone called..")
             }
 
+            "setOffline" -> {
+                val client = Amplitude.getInstance(instanceName)
+                client.setOffline(json.getBoolean("offline"))
+
+                result.success("setOffline called..")
+            }
+
             else -> {
                 result.notImplemented()
             }

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -197,6 +197,11 @@ import Amplitude
                     Amplitude.instance(withName: instanceName).setServerZone(ampServerZone, updateServerUrl: updateServerUrl)
                     result(true)
 
+                case "setOffline":
+                    let offline = args["offline"] as! Bool
+                    Amplitude.instance(withName: instanceName).setOffline(offline)
+                    result(true)
+
                 default:
                     result(FlutterMethodNotImplemented)
                 }

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -322,4 +322,13 @@ class Amplitude extends _Amplitude {
 
     return await _channel.invokeMethod('setServerZone', jsonEncode(properties));
   }
+
+  /// Sets offline. If offline is true, then the SDK will not upload events to Amplitude servers;
+  /// however, it will still log events.
+  Future<void> setOffline(bool enabled) async {
+    Map<String, dynamic> properties = _baseProperties();
+    properties['offline'] = enabled;
+
+    return await _channel.invokeMethod('setOffline', jsonEncode(properties));
+  }
 }


### PR DESCRIPTION
Expose the "setOffline" method, already available on the Android/iOS Amplitude SDKs.

Closes the following feature request: #81 