### PR TITLE
feat: add setEventUploadPeriodMillis support

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -113,6 +113,12 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler {
 
                 result.success("setEventUploadThreshold called..")
             }
+            "setEventUploadPeriodMillis" -> {
+                val client = Amplitude.getInstance(instanceName)
+                client.setEventUploadPeriodMillis(json.getInt("eventUploadPeriodMillis"))
+
+                result.success("setEventUploadPeriodMillis called..")
+            }
             "trackingSessionEvents" -> {
                 val client = Amplitude.getInstance(instanceName)
                 client.trackSessionEvents(json.getBoolean("trackingSessionEvents"))

--- a/example/README.md
+++ b/example/README.md
@@ -17,8 +17,15 @@ samples, guidance on mobile development, and a full API reference.
 
 
 ## Run the example
-Assuming you have Flutter setup on your machine.
+Assuming you have Flutter setup on your machine. 
 
+### Android & iOS
+Open the emulator you want to test on (Android, iOS)
 ```shell
 flutter run
+```
+
+### Browser
+```shell
+flutter run -d chrome
 ```

--- a/example/README.md
+++ b/example/README.md
@@ -14,3 +14,11 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter, view our 
 [online documentation](https://flutter.io/docs), which offers tutorials, 
 samples, guidance on mobile development, and a full API reference.
+
+
+## Run the example
+Assuming you have Flutter setup on your machine.
+
+```shell
+flutter run
+```

--- a/example/lib/flush_thresholds_form.dart
+++ b/example/lib/flush_thresholds_form.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+
+import 'app_state.dart';
+
+class FlushThresholdForm extends StatefulWidget {
+  @override
+  _FlushThresholdFormState createState() => _FlushThresholdFormState();
+}
+
+class _FlushThresholdFormState extends State<FlushThresholdForm> {
+  final TextEditingController eventUploadThresholdInput =
+      TextEditingController(text: '5');
+  final TextEditingController eventUploadPeriodMillisInput =
+      TextEditingController(text: '30000');
+  final EdgeInsetsGeometry contentPadding = EdgeInsets.symmetric(horizontal: 8, vertical: 8);
+
+  void onPressSetUploadThreshold() {
+    final value = int.tryParse(eventUploadThresholdInput.text);
+
+    if (eventUploadThresholdInput.text.isNotEmpty && value != null) {
+      AppState.of(context)
+        ..analytics.setEventUploadThreshold(value!)
+        ..setMessage('Event upload threshold set.');
+    }
+  }
+
+  void onPressSetEventUploadPeriodMillis() {
+    final value = int.tryParse(eventUploadPeriodMillisInput.text);
+
+    if (eventUploadPeriodMillisInput.text.isNotEmpty && value != null) {
+      AppState.of(context)
+        ..analytics.setEventUploadPeriodMillis(value!)
+        ..setMessage('Event upload period millis set.');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text('Flush Intervals', style: Theme.of(context).textTheme.headline5),
+        const SizedBox(height: 10),
+        TextField(
+            decoration: InputDecoration(
+                filled: true,
+                contentPadding: contentPadding,
+                labelText: 'Event Upload Threshold'),
+            controller: eventUploadThresholdInput),
+        ElevatedButton(
+            child: const Text('Set Event Upload Threshold'),
+            onPressed: onPressSetUploadThreshold),
+        const SizedBox(height: 10),
+        TextField(
+            decoration: InputDecoration(
+                filled: true,
+                contentPadding: contentPadding,
+                labelText: 'Event Upload Period (Milliseconds)'),
+            controller: eventUploadPeriodMillisInput),
+        ElevatedButton(
+            child: const Text('Set Event Upload Period'),
+            onPressed: onPressSetEventUploadPeriodMillis)
+      ],
+    );
+  }
+}

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:amplitude_flutter/amplitude.dart';
+import 'package:amplitude_flutter_example/flush_thresholds_form.dart';
 import 'package:flutter/material.dart';
 
 import 'app_state.dart';
@@ -40,6 +41,7 @@ class _MyAppState extends State<MyApp> {
     analytics.trackingSessionEvents(true);
     analytics.setMinTimeBetweenSessionsMillis(5000);
     analytics.setEventUploadThreshold(5);
+    analytics.setEventUploadPeriodMillis(30000);
     analytics.setServerZone("US");
     analytics.logEvent('MyApp startup',
         eventProperties: {'event_prop_1': 10, 'event_prop_2': true});
@@ -103,6 +105,8 @@ class _MyAppState extends State<MyApp> {
                 GroupIdentifyForm(),
                 divider,
                 RevenueForm(),
+                divider,
+                FlushThresholdForm(),
                 divider,
                 ElevatedButton(
                   child: const Text('Flush Events'),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,21 +28,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -63,7 +56,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -92,28 +85,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -125,7 +118,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -146,21 +139,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -8,7 +8,7 @@ import Amplitude
         let instance = SwiftAmplitudeFlutterPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
-    
+
     public func getPropertiesFromArguments(_ callArguments: Any?) throws -> [String:Any]? {
         if let arguments = callArguments, let data = (arguments as! String).data(using: .utf8) {
 
@@ -39,8 +39,8 @@ import Amplitude
                     }
                     else {
                         Amplitude.instance(withName: instanceName).initializeApiKey(apiKey)
-                    }   
-                    
+                    }
+
                     result(true)
 
                 // Get userId
@@ -77,6 +77,10 @@ import Amplitude
                 case "setEventUploadThreshold":
                     let eventUploadThreshold = args["eventUploadThreshold"] as! Int32
                     Amplitude.instance(withName: instanceName).eventUploadThreshold = eventUploadThreshold
+                    result(true)
+                case "setEventUploadPeriodMillis":
+                    let eventUploadPeriodMillis = args["eventUploadPeriodMillis"] as! Int32
+                    Amplitude.instance(withName: instanceName).eventUploadPeriodSeconds = eventUploadPeriodMillis / 1000
                     result(true)
                 case "trackingSessionEvents":
                     let trackingSessionEvents = args["trackingSessionEvents"] as! Bool
@@ -206,10 +210,10 @@ import Amplitude
                                      message: "Exception happened in handle.", details: nil))
         }
     }
-    
+
     private func createIdentify(_ userProperties: [String: [String : NSObject]]) -> AMPIdentify {
         let identify = AMPIdentify()
-        
+
         for (operation, properties) in userProperties {
             for (key, value) in properties {
                 switch operation {

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -107,6 +107,14 @@ class Amplitude extends _Amplitude {
         'setEventUploadThreshold', jsonEncode(properties));
   }
 
+  Future<void> setEventUploadPeriodMillis(int value) async {
+    Map<String, dynamic> properties = _baseProperties();
+    properties['eventUploadPeriodMillis'] = value;
+
+    await _channel.invokeMethod(
+        'setEventUploadPeriodMillis', jsonEncode(properties));
+  }
+
   /// Regenerates a new random deviceId for current user.
   /// Note: this is not recommended unless you know what you are doing.
   /// This can be used in conjunction with setUserId(null) to anonymize users after they log out.

--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -69,6 +69,11 @@ class AmplitudeFlutterPlugin {
           int eventUploadThreshold = args['eventUploadThreshold'];
           return amplitude.setEventUploadThreshold(eventUploadThreshold);
         }
+      case "setEventUploadPeriodMillis":
+        {
+          int eventUploadPeriodMillis = args['eventUploadPeriodMillis'];
+          return amplitude.options.eventUploadPeriodMillis = eventUploadPeriodMillis;
+        }
       case "regenerateDeviceId":
         {
           return amplitude.regenerateDeviceId();

--- a/lib/web/amplitude_js.dart
+++ b/lib/web/amplitude_js.dart
@@ -2,6 +2,11 @@
 
 import 'package:js/js.dart';
 
+@JS('amplitude.options')
+class Options {
+  external set eventUploadPeriodMillis(int value);
+}
+
 @JS('amplitude')
 class Amplitude {
   external Amplitude(String instanceName);
@@ -36,6 +41,7 @@ class Amplitude {
       Function? opt_callback,
       Function? opt_error_callback,
       bool? outOfSession);
+  external Options options;
 }
 
 @JS('amplitude.Identify')


### PR DESCRIPTION
Summary
* Added new `setEventUploadPeriodMillis` method to configure underlying SDKs
* Should support Android, iOS, and web
* Web implementation is questionable, better implementation would require updates to `amplitude-js`
* Added "Flush Intervals" section to the example app to test "setEventUploadThreshold" and "setEventUploadPeriodMillis"