### PR TITLE
Expose "setOffline" method

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -244,6 +244,13 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler {
                 result.success("setServerZone called..")
             }
 
+            "setOffline" -> {
+                val client = Amplitude.getInstance(instanceName)
+                client.setOffline(json.getBoolean("offline"))
+
+                result.success("setOffline called..")
+            }
+
             else -> {
                 result.notImplemented()
             }

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -197,6 +197,11 @@ import Amplitude
                     Amplitude.instance(withName: instanceName).setServerZone(ampServerZone, updateServerUrl: updateServerUrl)
                     result(true)
 
+                case "setOffline":
+                    let offline = args["offline"] as! Bool
+                    Amplitude.instance(withName: instanceName).setOffline(offline)
+                    result(true)
+
                 default:
                     result(FlutterMethodNotImplemented)
                 }

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -322,4 +322,13 @@ class Amplitude extends _Amplitude {
 
     return await _channel.invokeMethod('setServerZone', jsonEncode(properties));
   }
+
+  /// Sets offline. If offline is true, then the SDK will not upload events to Amplitude servers;
+  /// however, it will still log events.
+  Future<void> setOffline(bool enabled) async {
+    Map<String, dynamic> properties = _baseProperties();
+    properties['offline'] = enabled;
+
+    return await _channel.invokeMethod('setOffline', jsonEncode(properties));
+  }
 }

--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -179,7 +179,9 @@ class AmplitudeFlutterPlugin {
           return amplitude.setServerZone(serverZone, updateServerUrl);
         }
       case "setOffline":
-        return false;
+        {
+          return false;
+        }
       default:
         throw PlatformException(
           code: 'Unimplemented',

--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -1,10 +1,11 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:js/js_util.dart' as js;
+
 import 'web/amplitude_js.dart';
-import 'dart:async';
 
 class AmplitudeFlutterPlugin {
   static void registerWith(Registrar registrar) {
@@ -172,6 +173,8 @@ class AmplitudeFlutterPlugin {
           bool updateServerUrl = args['updateServerUrl'];
           return amplitude.setServerZone(serverZone, updateServerUrl);
         }
+      case "setOffline":
+        return false;
       default:
         throw PlatformException(
           code: 'Unimplemented',

--- a/lib/web/amplitude_js.dart
+++ b/lib/web/amplitude_js.dart
@@ -36,6 +36,7 @@ class Amplitude {
       Function? opt_callback,
       Function? opt_error_callback,
       bool? outOfSession);
+  external bool setOffline(bool enabled);
 }
 
 @JS('amplitude.Identify')


### PR DESCRIPTION
Expose the "setOffline" method, already available on the Android/iOS Amplitude SDKs.

Closes the following feature request: https://github.com/amplitude/Amplitude-Flutter/issues/81