### PR TITLE
Fix #150 - include nested objects in mapToJSObj

### DIFF
--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -190,7 +190,7 @@ class AmplitudeFlutterPlugin {
     var object = js.newObject();
     map.forEach((k, v) {
       var key = k;
-      var value = v;
+      var value = (v is Map) ? mapToJSObj(v) : v;
       js.setProperty(object, key, value);
     });
     return object;


### PR DESCRIPTION
This should fix issue #150 where nested objects are not included when sending events with nested `eventProperties` objects by recursively calling `mapToJSObj` if the value is a map.