### PR TITLE
chore: bump version to 3.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.16.0
+* Bump Amplitude Android SDK version (2.39.8) with session race condition fix.
+* Add `setOffline` method. Thanks @nishiths23!
+* Fix nested event properties in Web. Thanks @jtothebell!
+
 ## 3.15.0
 * Bump Amplitude Android SDK version (2.39.4)
 * Bump Amplitude iOS SDK version (8.16.1)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.15.0"
+    version: "3.16.0"
   async:
     dependency: transitive
     description:

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,4 +1,4 @@
 class Constants {
   static const packageName = 'amplitude-flutter';
-  static const packageVersion = '3.15.0';
+  static const packageVersion = '3.16.0';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: amplitude_flutter
 description: Amplitude Flutter plugin
-version: 3.15.0
+version: 3.16.0
 homepage: https://www.amplitude.com
 repository: https://github.com/amplitude/Amplitude-Flutter
 


### PR DESCRIPTION
* Bump version to `3.16.0`
* Bump Amplitude Android SDK version (2.39.8) with session race condition fix.
* Add `setOffline` method
* Fix nested event properties in Web