### PR TITLE
fix: add release/publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,38 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  publish:
+    name: Publish
+
+    permissions:
+      id-token: write # Required for authentication using OIDC
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # This step sets the GitHub-signed OIDC token for pub.dev
+      # Workaround for https://github.com/dart-lang/setup-dart/issues/68
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Check Flutter version
+        run: flutter --version
+
+      - name: Publish to pub.dev
+        run: flutter pub publish --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Do a dry run to preview instead of a real release'
+        type: choice
+        required: true
+        default: 'true'
+        options:
+          - 'true'
+          - 'false'
+
+jobs:
+  authorize:
+    name: Authorize
+    runs-on: ubuntu-latest
+    steps:
+      - name: ${{ github.actor }} permission check to do a release
+        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        with:
+          permission: "write"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [authorize]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      - name: Check Flutter version
+        run: flutter --version
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze --no-fatal-infos
+
+#      - name: Test
+#        run: flutter test
+
+      - name: Semantic Release --dry-run
+        if: ${{ github.event.inputs.dryRun == 'true'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: amplitude-sdk-bot
+          GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+          GIT_COMMITTER_NAME: amplitude-sdk-bot
+          GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+        run: |
+          npx \
+          -p lodash \
+          -p semantic-release@17 \
+          -p @semantic-release/changelog@5 \
+          -p @semantic-release/git@9 \
+          -p @google/semantic-release-replace-plugin@1.2.0 \
+          -p @semantic-release/exec@5 \
+          semantic-release --dry-run
+
+      - name: Semantic Release
+        if: ${{ github.event.inputs.dryRun == 'false'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: amplitude-sdk-bot
+          GIT_AUTHOR_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+          GIT_COMMITTER_NAME: amplitude-sdk-bot
+          GIT_COMMITTER_EMAIL: amplitude-sdk-bot@users.noreply.github.com
+        run: |
+          npx \
+          -p lodash \
+          -p semantic-release@17 \
+          -p @semantic-release/changelog@5 \
+          -p @semantic-release/git@9 \
+          -p @google/semantic-release-replace-plugin@1.2.0 \
+          -p @semantic-release/exec@5 \
+          semantic-release

--- a/example/lib/flush_thresholds_form.dart
+++ b/example/lib/flush_thresholds_form.dart
@@ -19,7 +19,7 @@ class _FlushThresholdFormState extends State<FlushThresholdForm> {
 
     if (eventUploadThresholdInput.text.isNotEmpty && value != null) {
       AppState.of(context)
-        ..analytics.setEventUploadThreshold(value!)
+        ..analytics.setEventUploadThreshold(value)
         ..setMessage('Event upload threshold set.');
     }
   }
@@ -29,7 +29,7 @@ class _FlushThresholdFormState extends State<FlushThresholdForm> {
 
     if (eventUploadPeriodMillisInput.text.isNotEmpty && value != null) {
       AppState.of(context)
-        ..analytics.setEventUploadPeriodMillis(value!)
+        ..analytics.setEventUploadPeriodMillis(value)
         ..setMessage('Event upload period millis set.');
     }
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -12,49 +12,56 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.2"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: d57953e10f9f8327ce64a508a355f0b1ec902193f66288e8cb5070e7c47eeb2d
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.6"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   flutter:
@@ -76,37 +83,42 @@ packages:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: a5e201311cb08bf3912ebbe9a2be096e182d703f881136ec1e81a2338a9e120d
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -116,51 +128,66 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=2.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.6
 
 dev_dependencies:
   flutter_test:

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,74 @@
+module.exports = {
+  "branches": [
+    "main"
+  ],
+  "tagFormat": ["v${version}"],
+  "plugins": [
+    ["@semantic-release/commit-analyzer", {
+      "preset": "angular",
+      "parserOpts": {
+        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+      }
+    }],
+    ["@semantic-release/release-notes-generator", {
+      "preset": "angular",
+    }],
+    ["@semantic-release/changelog", {
+      "changelogFile": "CHANGELOG.md"
+    }],
+    "@semantic-release/github",
+    [
+      "@google/semantic-release-replace-plugin",
+      {
+        "replacements": [
+          {
+            "files": ["pubspec.yaml"],
+            "from": "version: .*",
+            "to": "version: ${nextRelease.version}",
+            "results": [
+              {
+                "file": "pubspec.yaml",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          },
+          {
+            "files": ["lib/constants.dart"],
+            "from": "static const packageVersion = '.*';",
+            "to": "static const packageVersion = '${nextRelease.version}';",
+            "results": [
+              {
+                "file": "lib/constants.dart",
+                "hasChanged": true,
+                "numMatches": 1,
+                "numReplacements": 1
+              }
+            ],
+            "countMatches": true
+          },
+          {
+            "files": ["example/pubspec.lock"],
+            "from": /(amplitude_flutter:(.|\n)*?)version: ".*"/,
+            "to": "$1version: \"${nextRelease.version}\"",
+            "results": [
+              {
+                "file": "example/pubspec.lock",
+                "hasChanged": true,
+                "numMatches": 3,
+                "numReplacements": 3
+              }
+            ],
+            "countMatches": true
+          },
+        ]
+      }
+    ],
+    ["@semantic-release/git", {
+      "assets": ["pubspec.yaml", "CHANGELOG.md", "lib/constants.dart", "example/pubspec.lock"],
+      "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
+    }],
+  ],
+}


### PR DESCRIPTION
Added 2 workflows:
1. `release` (manual) - bumps version, creates/pushes a commit/tag.
2. `publish` (auto-triggered on `push`) - publishes new version to pub.dev

`release` workflow:

A deploy key (public part) should be added to the repo with write access. Private part of the key should be added as a repo secret `DEPLOY_KEY`.

`publish` workflow:
https://dart.dev/tools/pub/automated-publishing#publishing-packages-using-github-actions

Need to setup `Publishing from GitHub Actions` in package settings:
![image](https://github.com/amplitude/Amplitude-Flutter/assets/9509929/8cda7822-b284-4980-a943-977e48d63312)

I use latest Flutter/Dart versions: 3.13.3/3.1.1. `example/pubspec.lock` was updated by `flutter pub get`  command (also `cupertino_icons` should be bumped to `^1.0.6` in `example/pubspec.yaml`)

I think the example should be updated to recent Flutter/Dart versions. It doesn't work for me (may depend on Android Studio version in addition to Flutter/Dart versions).

`flutter analyze` command outputs 12 info messages and 2 warnings. I fixed the 2 warnings. For now I use command `flutter analyze --no-fatal-infos` to ignore info messages. ` --no-fatal-infos` flag can be removed after we update the example.

Info messages:
```
Analyzing example...                                                    

   info • The import of 'package:flutter/foundation.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart' • lib/app_state.dart:2:8 • unnecessary_import
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/deviceid_sessionid.dart:16:66 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/deviceid_sessionid.dart:31:67 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/event_form.dart:25:58 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/flush_thresholds_form.dart:42:68 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/group_form.dart:32:68 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/group_identify_form.dart:44:67 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/identify_form.dart:38:61 • deprecated_member_use
   info • 'bodyText1' is deprecated and shouldn't be used. Use bodyLarge instead. This feature was deprecated after v3.1.0-0.0.pre • lib/my_app.dart:115:67 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/revenue_form.dart:41:60 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/user_id_form.dart:22:68 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • lib/user_id_form.dart:30:60 • deprecated_member_use
```