### PR TITLE
Added the namespace property in build.gradle if the field is necessary.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,10 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 28
+    // Condition for namespace compatibility in AGP 8
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.amplitude.amplitude_flutter'
+    }
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
This PR branch provide the package namespace if the AGP is equal or higher then 8.

Please Review: @yuhao900914  and @Mercy811.