### PR TITLE
ci: add pr test and lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: Test and Lint
+
+on: [pull_request]
+
+jobs:
+  test:
+    name: Check the source code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+
+      - name: Check Flutter version
+        run: flutter --version
+
+      - name: Install packages
+        run: flutter pub get
+
+      - name: Linter
+        run: flutter analyze
+
+      - name: Test
+        run: flutter test

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -1,0 +1,43 @@
+name: Semantic PR Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+
+jobs:
+  pr-title-check:
+    name: Check PR for semantic title
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR title is valid
+        if: >
+          startsWith(github.event.pull_request.title, 'feat:') || startsWith(github.event.pull_request.title, 'feat(') ||
+          startsWith(github.event.pull_request.title, 'fix:') || startsWith(github.event.pull_request.title, 'fix(') ||
+          startsWith(github.event.pull_request.title, 'perf:') || startsWith(github.event.pull_request.title, 'perf(') ||
+          startsWith(github.event.pull_request.title, 'docs:') || startsWith(github.event.pull_request.title, 'docs(') ||
+          startsWith(github.event.pull_request.title, 'test:') || startsWith(github.event.pull_request.title, 'test(') ||
+          startsWith(github.event.pull_request.title, 'refactor:') || startsWith(github.event.pull_request.title, 'refactor(') ||
+          startsWith(github.event.pull_request.title, 'style:') || startsWith(github.event.pull_request.title, 'style(') ||
+          startsWith(github.event.pull_request.title, 'build:') || startsWith(github.event.pull_request.title, 'build(') ||
+          startsWith(github.event.pull_request.title, 'ci:') || startsWith(github.event.pull_request.title, 'ci(') ||
+          startsWith(github.event.pull_request.title, 'chore:') || startsWith(github.event.pull_request.title, 'chore(') ||
+          startsWith(github.event.pull_request.title, 'revert:') || startsWith(github.event.pull_request.title, 'revert(')
+        run: |
+          echo 'Title checks passed'
+
+      - name: PR title is invalid
+        if: >
+          !startsWith(github.event.pull_request.title, 'feat:') && !startsWith(github.event.pull_request.title, 'feat(') &&
+          !startsWith(github.event.pull_request.title, 'fix:') && !startsWith(github.event.pull_request.title, 'fix(') &&
+          !startsWith(github.event.pull_request.title, 'perf:') && !startsWith(github.event.pull_request.title, 'perf(') &&
+          !startsWith(github.event.pull_request.title, 'docs:') && !startsWith(github.event.pull_request.title, 'docs(') &&
+          !startsWith(github.event.pull_request.title, 'test:') && !startsWith(github.event.pull_request.title, 'test(') &&
+          !startsWith(github.event.pull_request.title, 'refactor:') && !startsWith(github.event.pull_request.title, 'refactor(') &&
+          !startsWith(github.event.pull_request.title, 'style:') && !startsWith(github.event.pull_request.title, 'style(') &&
+          !startsWith(github.event.pull_request.title, 'build:') && !startsWith(github.event.pull_request.title, 'build(') &&
+          !startsWith(github.event.pull_request.title, 'ci:') && !startsWith(github.event.pull_request.title, 'ci(') &&
+          !startsWith(github.event.pull_request.title, 'chore:') && !startsWith(github.event.pull_request.title, 'chore(') &&
+          !startsWith(github.event.pull_request.title, 'revert:') && !startsWith(github.event.pull_request.title, 'revert(')
+        run: |
+          echo 'Pull request title is not valid. Please check github.com/amplitude/Amplitude-Flutter/blob/main/CONTRIBUTING.md#pr-commit-title-conventions'
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,24 @@ You can checkout the the official Flutter documentation on [getting started](htt
 Checkout the [set up and editor](https://flutter.dev/docs/get-started/editor?tab=vscode) and [test drive](https://flutter.dev/docs/get-started/test-drive) sections of the official Flutter documentation on setting up your environment. 
 
 You should then be able to run the Flutter project in `example/` which has the Amplitude Flutter SDK installed.
+
+## Practices
+
+### PR Commit Title Conventions
+
+PR titles should follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/). This helps automate the release process.
+
+#### Commit Types
+
+- **Special Case**: Any commit with `BREAKING CHANGES` in the body: Creates major release
+- `feat(<optional scope>)`: New features (minimum minor release)
+- `fix(<optional scope>)`: Bug fixes (minimum patch release)
+- `perf(<optional scope>)`: Performance improvement
+- `docs(<optional scope>)`: Documentation updates
+- `test(<optional scope>)`: Test updates
+- `refactor(<optional scope>)`: Code change that neither fixes a bug nor adds a feature
+- `style(<optional scope>)`: Code style changes (e.g. formatting, commas, semi-colons)
+- `build(<optional scope>)`: Changes that affect the build system or external dependencies (e.g. Yarn, Npm)
+- `ci(<optional scope>)`: Changes to our CI configuration files and scripts
+- `chore(<optional scope>)`: Other changes that don't modify src or test files
+- `revert(<optional scope>)`: Revert commit

--- a/example/lib/app_state.dart
+++ b/example/lib/app_state.dart
@@ -1,5 +1,4 @@
 import 'package:amplitude_flutter/amplitude.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class AppState extends InheritedWidget {

--- a/example/lib/deviceid_sessionid.dart
+++ b/example/lib/deviceid_sessionid.dart
@@ -13,7 +13,7 @@ class _DeviceIdSessionIdState extends State<DeviceIdSessionId> {
       children: [
         Row(
           children: [
-            Text('Device Id', style: Theme.of(context).textTheme.headline5),
+            Text('Device Id', style: Theme.of(context).textTheme.headlineSmall),
           ],
         ),
         Row(
@@ -28,7 +28,7 @@ class _DeviceIdSessionIdState extends State<DeviceIdSessionId> {
         ),
         Row(
           children: [
-            Text('Session Id', style: Theme.of(context).textTheme.headline5),
+            Text('Session Id', style: Theme.of(context).textTheme.headlineSmall),
           ],
         ),
         Row(children: [

--- a/example/lib/event_form.dart
+++ b/example/lib/event_form.dart
@@ -22,7 +22,7 @@ class _EventFormState extends State<EventForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Event', style: Theme.of(context).textTheme.headline5),
+        Text('Event', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         TextField(
             decoration: InputDecoration(

--- a/example/lib/flush_thresholds_form.dart
+++ b/example/lib/flush_thresholds_form.dart
@@ -39,7 +39,7 @@ class _FlushThresholdFormState extends State<FlushThresholdForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Flush Intervals', style: Theme.of(context).textTheme.headline5),
+        Text('Flush Intervals', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         TextField(
             decoration: InputDecoration(

--- a/example/lib/group_form.dart
+++ b/example/lib/group_form.dart
@@ -29,7 +29,7 @@ class _GroupFormState extends State<GroupForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Group / Account', style: Theme.of(context).textTheme.headline5),
+        Text('Group / Account', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         Row(children: <Widget>[
           Expanded(

--- a/example/lib/group_identify_form.dart
+++ b/example/lib/group_identify_form.dart
@@ -41,7 +41,7 @@ class _GroupIdentifyFormState extends State<GroupIdentifyForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Group Identify', style: Theme.of(context).textTheme.headline5),
+        Text('Group Identify', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         Row(children: <Widget>[
           Expanded(

--- a/example/lib/identify_form.dart
+++ b/example/lib/identify_form.dart
@@ -35,7 +35,7 @@ class _IdentifyFormState extends State<IdentifyForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Identify', style: Theme.of(context).textTheme.headline5),
+        Text('Identify', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         Row(children: <Widget>[
           Expanded(

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -112,7 +112,7 @@ class _MyAppState extends State<MyApp> {
                   child: const Text('Flush Events'),
                   onPressed: _flushEvents,
                 ),
-                Text(_message, style: Theme.of(context).textTheme.bodyText1)
+                Text(_message, style: Theme.of(context).textTheme.bodyLarge)
               ],
             ),
           ),

--- a/example/lib/revenue_form.dart
+++ b/example/lib/revenue_form.dart
@@ -38,7 +38,7 @@ class _RevenueFormState extends State<RevenueForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Revenue', style: Theme.of(context).textTheme.headline5),
+        Text('Revenue', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         TextField(
             decoration: dec.copyWith(labelText: 'Product Id'),

--- a/example/lib/user_id_form.dart
+++ b/example/lib/user_id_form.dart
@@ -19,7 +19,7 @@ class _UserIdFormState extends State<UserIdForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Current User Id', style: Theme.of(context).textTheme.headline5),
+        Text('Current User Id', style: Theme.of(context).textTheme.headlineSmall),
         FutureBuilder(
           future: AppState.of(context).analytics.getUserId(),
           builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
@@ -27,7 +27,7 @@ class _UserIdFormState extends State<UserIdForm> {
           },
         ),
         const SizedBox(height: 10),
-        Text('User Id', style: Theme.of(context).textTheme.headline5),
+        Text('User Id', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         new TextField(
             autocorrect: false,

--- a/lib/web/amplitude_js.dart
+++ b/lib/web/amplitude_js.dart
@@ -38,7 +38,9 @@ class Amplitude {
       String groupType,
       String groupName,
       Identify groupIdentify,
+      // ignore: non_constant_identifier_names
       Function? opt_callback,
+      // ignore: non_constant_identifier_names
       Function? opt_error_callback,
       bool? outOfSession);
   external bool setOffline(bool enabled);


### PR DESCRIPTION

- `.github/workflows/ci.yml`
  - Run test and linter on pull request.
- `.github/workflows/semantic-pr.yml`
  - Add semantic check
- `lib/web/amplitude_js.dart`
  - Not sure if changing to camel case will break it so ignore lint rule for these two
- `example/*.*`, 
  - fix current lint errors by `dart fix --apply`

```
> flutter analyze                                                                                                                                                                                                                                                           ─╯
Analyzing Amplitude-Flutter...                                          

   info • The import of 'package:flutter/foundation.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter/material.dart' • example/lib/app_state.dart:2:8 • unnecessary_import
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/deviceid_sessionid.dart:16:66 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/deviceid_sessionid.dart:31:67 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/event_form.dart:25:58 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/flush_thresholds_form.dart:42:68 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/group_form.dart:32:68 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/group_identify_form.dart:44:67 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/identify_form.dart:38:61 • deprecated_member_use
   info • 'bodyText1' is deprecated and shouldn't be used. Use bodyLarge instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/my_app.dart:115:67 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/revenue_form.dart:41:60 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/user_id_form.dart:22:68 • deprecated_member_use
   info • 'headline5' is deprecated and shouldn't be used. Use headlineSmall instead. This feature was deprecated after v3.1.0-0.0.pre • example/lib/user_id_form.dart:30:60 • deprecated_member_use
   info • The variable name 'opt_callback' isn't a lowerCamelCase identifier • lib/web/amplitude_js.dart:41:17 • non_constant_identifier_names
   info • The variable name 'opt_error_callback' isn't a lowerCamelCase identifier • lib/web/amplitude_js.dart:42:17 • non_constant_identifier_names

14 issues found. (ran in 1.0s)

```
