### PR TITLE
chore: enable app lifecycle and deep link events

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -19,10 +19,11 @@ import android.content.pm.PackageManager
 import com.amplitude.android.utilities.DefaultEventUtils
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import java.lang.ref.WeakReference
 
 class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     lateinit var amplitude: Amplitude
-    private var activity: Activity? = null
+    private var activity: WeakReference<Activity?> = WeakReference(null)
     lateinit var ctxt: Context
 
     private lateinit var channel: MethodChannel
@@ -33,19 +34,19 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
-        activity = binding.activity
+        activity = WeakReference(binding.activity)
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
-        activity = null
+        activity = WeakReference(null)
     }
 
     override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
-        activity = binding.activity
+        activity = WeakReference(binding.activity)
     }
 
     override fun onDetachedFromActivity() {
-        activity = null
+        activity = WeakReference(null)
     }
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
@@ -163,7 +164,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
                 if (appLifecycles) {
                     val packageManager = ctxt.packageManager
-                    var packageInfo = try {
+                    val packageInfo = try {
                         packageManager.getPackageInfo(ctxt.packageName, 0)
                     } catch (ex: PackageManager.NameNotFoundException) {
                         println("Error occurred in getting package info. " + ex.message)
@@ -173,7 +174,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 }
 
                 if (deepLinks) {
-                    activity?.let { utils.trackDeepLinkOpenedEvent(it) }
+                    activity.get()?.let { utils.trackDeepLinkOpenedEvent(it) }
                 }
             }
         }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -40,6 +40,18 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Deep link to open this activity -->
+                <data
+                    android:scheme="app"
+                    android:host="amplitude_flutter_example" />
+            </intent-filter>
         </activity>
     </application>
     <meta-data


### PR DESCRIPTION
- Enable "application installed" and "application updated" and "deep link" events. 
  - They are not default out of box because of how SDK inits in a Flutter app is different than in a Android native app
- Manual tests
  - Sessions
    - [Start session](https://app.amplitude.com/analytics/amplitude/project/471621/search/amplitude_id%3D841344671124?sessionHandle=Y32Enl3_Y32Enl3_MPkDN2U_BzJF_2996b2a8-2a4b-432c-bd16-a8601a304b20R&eventId=5851b0b7-caca-4598-91e1-309c4a89bc42)
    - [End session](https://app.amplitude.com/analytics/amplitude/project/471621/search/amplitude_id%3D839261981647?sessionHandle=Y315ib9_Y315ib9_MNn6YvP_BzJF_Xinyi%2527s%2520pixel&eventId=22497c9c-f6a8-41dc-8a42-13bd3beb447c)
  - App lifecycles
    - [[Amplitude] Application Installed](https://app.amplitude.com/analytics/amplitude/project/471621/search/amplitude_id%3D839261981647?sessionHandle=Y315ib9_Y315ib9_MNn6YvP_BzJF_Xinyi%2527s%2520pixel&eventId=10d4ab45-87e4-4466-9647-51e05f964b1e) 
    - [[Amplitude] Application Updated ](https://app.amplitude.com/analytics/amplitude/project/471621/search/amplitude_id%3D839261981647?sessionHandle=Y32CHoM_Y32CHoM_MNn6YvP_BzJF_Xinyi%2527s%2520pixel&eventId=5efdd9d9-2bec-4ed3-9369-a43db9c53076)
    - [[Amplitude] Application Opened](https://app.amplitude.com/analytics/amplitude/project/471621/search/amplitude_id%3D841344671124?sessionHandle=Y32Enl3_Y32Enl3_MPkDN2U_BzJF_2996b2a8-2a4b-432c-bd16-a8601a304b20R&eventId=cd913c39-29c2-4b41-b743-d010a6825d22)
    - [[Amplitude] Application Backgrounded](https://app.amplitude.com/analytics/amplitude/project/471621/search/amplitude_id%3D841344671124?sessionHandle=Y32Enl3_Y32Enl3_MPkDN2U_BzJF_2996b2a8-2a4b-432c-bd16-a8601a304b20R&eventId=d2d1d11d-fec6-47b9-aba2-baae0b83aab5)
  - [Screen views](https://app.amplitude.com/analytics/amplitude/project/471621/search/amplitude_id%3D841344671124?sessionHandle=Y32Enl3_Y32Enl3_MPkDN2U_BzJF_2996b2a8-2a4b-432c-bd16-a8601a304b20R&eventId=f49afc83-6fdc-444d-a397-bf6d31a11d45) 
  - [Deep links](https://app.amplitude.com/analytics/amplitude/project/471621/search/amplitude_id%3D841414973251?sessionHandle=Y32eKZQ_Y32eKZQ_MPoPZdD_BzJF_ec868e81-552f-4d5f-aafe-9e3912c4147aR&eventId=19a58ebc-d472-4525-a261-e0a51c35b270) 