### PR TITLE
chore: set library

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,6 +1,6 @@
 class Constants {
   static const packageName = "amplitude-flutter";
-  static const packageVersion = "4.0.0-beta.0";
+  static const packageVersion = "3.16.1";
   static const identify_event = "\$identify";
   static const group_identify_event = "\$groupidentify";
   static const revenue_event = "revenue_amount";

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,6 +1,6 @@
 class Constants {
   static const packageName = "amplitude-flutter";
-  static const packageVersion = "3.16.1";
+  static const packageVersion = "4.0.0-beta.0";
   static const identify_event = "\$identify";
   static const group_identify_event = "\$groupidentify";
   static const revenue_event = "revenue_amount";

--- a/lib/events/base_event.dart
+++ b/lib/events/base_event.dart
@@ -1,3 +1,4 @@
+import 'package:amplitude_flutter/constants.dart';
 import 'package:amplitude_flutter/events/plan.dart';
 import 'event_options.dart';
 import 'ingestion_metadata.dart';
@@ -37,7 +38,7 @@ class BaseEvent extends EventOptions {
     String? appSetId,
     String? androidId,
     String? language,
-    String? library,
+    String library = "${Constants.packageName}/${Constants.packageVersion}",
     String? ip,
     Plan? plan,
     IngestionMetadata? ingestionMetadata,

--- a/test/amplitude_test.dart
+++ b/test/amplitude_test.dart
@@ -87,6 +87,7 @@ void main() {
   final testEvent = BaseEvent(eventType: "testEvent");
   final testEventMap = {
     "event_type": "testEvent",
+    "library": "${Constants.packageName}/${Constants.packageVersion}",
     "attempts": 0,
   };
   final testPrice = 3.99;


### PR DESCRIPTION
Set correct library. `packageVersion` in `lib/constants.dart` will be updated to the next semantic version [here](https://github.com/amplitude/Amplitude-Flutter/blob/9a8f1ce3d28a328916dc14746e54328df9bed7a5/release.config.js#L41) in release process. 

Example event with library `amplitude-flutter/4.0.0-beta.0`
https://app.amplitude.com/analytics/amplitude/project/471621/search/amplitude_id%3D841571714990?sessionHandle=Y33KhyN_Y33K%2Ft4_MPxlUeu_BzJF_4836ed76-622b-4760-a488-b3028363b5c0R&eventId=8ea03829-2e3d-4aa4-baf9-e9591577092c