### PR TITLE
chore: set library by plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,10 +21,16 @@ rootProject.allprojects {
     }
 }
 
+ext {
+    PUBLISH_VERSION = '4.0.0-beta.0'
+}
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    buildFeatures.buildConfig true
+
     compileSdkVersion 34
     // Condition for namespace compatibility in AGP 8
     if (project.android.hasProperty("namespace")) {
@@ -36,6 +42,9 @@ android {
     }
     defaultConfig {
         minSdkVersion 16
+
+        buildConfigField 'String', 'SDK_VERSION', "\"${PUBLISH_VERSION}\""
+
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -64,6 +64,10 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "init" -> {
                 val configuration = getConfiguration(call)
                 amplitude = Amplitude(configuration)
+
+                // Set library
+                amplitude.add(FlutterLibraryPlugin())
+
                 call.argument<String>("logLevel")?.let {
                     amplitude.logger.logMode = Logger.LogMode.valueOf(it.uppercase())
                 }

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/FlutterLibraryPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/FlutterLibraryPlugin.kt
@@ -1,0 +1,21 @@
+package com.amplitude.amplitude_flutter
+
+import com.amplitude.core.Amplitude
+import com.amplitude.core.events.BaseEvent
+import com.amplitude.core.platform.Plugin
+import com.amplitude.amplitude_flutter.BuildConfig
+
+class FlutterLibraryPlugin: Plugin {
+    override val type: Plugin.Type = Plugin.Type.Before
+    override lateinit var amplitude: Amplitude
+
+    companion object {
+        const val SDK_LIBRARY = "amplitude-flutter"
+        const val SDK_VERSION = BuildConfig.SDK_VERSION
+    }
+
+    override fun execute(event: BaseEvent): BaseEvent? {
+        event.library = "$SDK_LIBRARY/$SDK_VERSION"
+        return super.execute(event)
+    }
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,6 +1,4 @@
 class Constants {
-  static const packageName = "amplitude-flutter";
-  static const packageVersion = "3.16.1";
   static const identify_event = "\$identify";
   static const group_identify_event = "\$groupidentify";
   static const revenue_event = "revenue_amount";

--- a/lib/events/base_event.dart
+++ b/lib/events/base_event.dart
@@ -1,4 +1,3 @@
-import 'package:amplitude_flutter/constants.dart';
 import 'package:amplitude_flutter/events/plan.dart';
 import 'event_options.dart';
 import 'ingestion_metadata.dart';
@@ -38,7 +37,7 @@ class BaseEvent extends EventOptions {
     String? appSetId,
     String? androidId,
     String? language,
-    String library = "${Constants.packageName}/${Constants.packageVersion}",
+    String? library,
     String? ip,
     Plan? plan,
     IngestionMetadata? ingestionMetadata,

--- a/release.config.js
+++ b/release.config.js
@@ -63,6 +63,20 @@ module.exports = {
             ],
             "countMatches": true
           },
+          {
+            "files": ["android/build.gradle"],
+            "from": "PUBLISH_VERSION = \'.*\'",
+            "to": "PUBLISH_VERSION = \'${nextRelease.version}\'",
+            "results": [
+                {
+                  "file": "android/build.gradle",
+                  "hasChanged": true,
+                  "numMatches": 1,
+                  "numReplacements": 1
+                }
+            ],
+            "countMatches": true
+            },
         ]
       }
     ],

--- a/test/amplitude_test.dart
+++ b/test/amplitude_test.dart
@@ -87,7 +87,6 @@ void main() {
   final testEvent = BaseEvent(eventType: "testEvent");
   final testEventMap = {
     "event_type": "testEvent",
-    "library": "${Constants.packageName}/${Constants.packageVersion}",
     "attempts": 0,
   };
   final testPrice = 3.99;


### PR DESCRIPTION
Revert changes in https://github.com/amplitude/Amplitude-Flutter/pull/174. 

Only adding a setting library plugin can update all events including default events' library. 

1. Change PUBLISH_VERSION in `release.config.js` to the latest semantic version
2. `build.gradle` will then generate `BuildConfig.java`
3. Set library in `FlutterLibraryPlugin`


Example `BuildConfig.java`
```
/**
 * Automatically generated file. DO NOT MODIFY
 */
package com.amplitude.amplitude_flutter;

public final class BuildConfig {
  public static final boolean DEBUG = Boolean.parseBoolean("true");
  public static final String LIBRARY_PACKAGE_NAME = "com.amplitude.amplitude_flutter";
  public static final String BUILD_TYPE = "debug";
  // Field from default config.
  public static final String SDK_VERSION = "4.0.0-beta.0";
}

```

Events include default events are set to `amplitude-flutter/4.0.0-beta.0`
https://app.amplitude.com/analytics/amplitude/project/471621/search/amplitude_id%3D842311306390?sessionHandle=Y38ZXvS_Y38ZXvS_MQdqoyW_BzJF_6ebbafb4-dc1d-4bd7-8ad7-0ff29dceed93R&eventId=98a9598b-1f8f-42a2-924a-20cfcb268b77