### PR TITLE
refactor: update iOS bridge

### DIFF
--- a/.github/workflows/swift-lint.yml
+++ b/.github/workflows/swift-lint.yml
@@ -1,0 +1,17 @@
+name: Swift Lint
+
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: macos-12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set Xcode 14
+        run: |
+          sudo xcode-select -switch /Applications/Xcode_14.1.app
+
+      - name: Lint
+        run: cd ios && swiftlint --strict # force to fix warnings too

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,16 +21,10 @@ rootProject.allprojects {
     }
 }
 
-ext {
-    PUBLISH_VERSION = '4.0.0-beta.0'
-}
-
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    buildFeatures.buildConfig true
-
     compileSdkVersion 34
     // Condition for namespace compatibility in AGP 8
     if (project.android.hasProperty("namespace")) {
@@ -42,9 +36,6 @@ android {
     }
     defaultConfig {
         minSdkVersion 16
-
-        buildConfigField 'String', 'SDK_VERSION', "\"${PUBLISH_VERSION}\""
-
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -28,7 +28,6 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     private lateinit var channel: MethodChannel
 
-
     companion object {
         private const val methodChannelName = "amplitude_flutter"
     }
@@ -66,7 +65,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 amplitude = Amplitude(configuration)
 
                 // Set library
-                amplitude.add(FlutterLibraryPlugin())
+                amplitude.add(FlutterLibraryPlugin(call.argument<String>("library")!!))
 
                 call.argument<String>("logLevel")?.let {
                     amplitude.logger.logMode = Logger.LogMode.valueOf(it.uppercase())

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -65,7 +65,11 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 amplitude = Amplitude(configuration)
 
                 // Set library
-                amplitude.add(FlutterLibraryPlugin(call.argument<String>("library")!!))
+                amplitude.add(
+                    FlutterLibraryPlugin(
+                        call.argument<String>("library") ?: "amplitude-flutter/unknown"
+                    )
+                )
 
                 call.argument<String>("logLevel")?.let {
                     amplitude.logger.logMode = Logger.LogMode.valueOf(it.uppercase())

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -196,6 +196,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         call.argument<Boolean>("useBatch")?.let { configuration.useBatch = it }
         call.argument<String>("serverZone")
             ?.let { configuration.serverZone = com.amplitude.core.ServerZone.valueOf(it.uppercase()) }
+        call.argument<String>("serverUrl")?.let { configuration.serverUrl = it }
         call.argument<Int>("minTimeBetweenSessionsMillis")
             ?.let { configuration.minTimeBetweenSessionsMillis = it.toLong() }
         call.argument<Map<String, Any>>("defaultTracking")?.let { map ->

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -237,6 +237,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         (map["deviceManufacturer"] as? Boolean)?.let { if (!it) trackingOptions.disableDeviceManufacturer() }
         (map["osVersion"] as? Boolean)?.let { if (!it) trackingOptions.disableOsVersion() }
         (map["osName"] as? Boolean)?.let { if (!it) trackingOptions.disableOsName() }
+        (map["versionName"] as? Boolean)?.let { if (!it) trackingOptions.disableVersionName() }
         (map["adid"] as? Boolean)?.let { if (!it) trackingOptions.disableAdid() }
         (map["appSetId"] as? Boolean)?.let { if (!it) trackingOptions.disableAppSetId() }
         (map["deviceBrand"] as? Boolean)?.let { if (!it) trackingOptions.disableDeviceBrand() }

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -81,44 +81,12 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 result.success("init called..")
             }
 
-            "track" -> {
+            "track", "identify", "groupIdentify", "setGroup", "revenue" -> {
                 val event = getEvent(call)
                 amplitude.track(event)
-                amplitude.logger.debug("Track event: ${call.arguments}")
+                amplitude.logger.debug("Track ${call.method} event: ${call.arguments}")
 
-                result.success("track called..")
-            }
-
-            "identify" -> {
-                val event = getEvent(call)
-                amplitude.track(event)
-                amplitude.logger.debug("Track identify event: ${call.arguments}")
-
-                result.success("identify called..")
-            }
-
-            "groupIdentify" -> {
-                val event = getEvent(call)
-                amplitude.track(event)
-                amplitude.logger.debug("Track group identify event: ${call.arguments}")
-
-                result.success("groupIdentify called..")
-            }
-
-            "setGroup" -> {
-                val event = getEvent(call)
-                amplitude.track(event)
-                amplitude.logger.debug("Track set group event: ${call.arguments}")
-
-                result.success("setGroup called..")
-            }
-
-            "revenue" -> {
-                val event = getEvent(call)
-                amplitude.track(event)
-                amplitude.logger.debug("Track revenue event: ${call.arguments}")
-
-                result.success("revenue called..")
+                result.success("${call.method} called..")
             }
 
             "setUserId" -> {

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/FlutterLibraryPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/FlutterLibraryPlugin.kt
@@ -3,19 +3,13 @@ package com.amplitude.amplitude_flutter
 import com.amplitude.core.Amplitude
 import com.amplitude.core.events.BaseEvent
 import com.amplitude.core.platform.Plugin
-import com.amplitude.amplitude_flutter.BuildConfig
 
-class FlutterLibraryPlugin: Plugin {
+class FlutterLibraryPlugin(val library: String): Plugin {
     override val type: Plugin.Type = Plugin.Type.Before
     override lateinit var amplitude: Amplitude
 
-    companion object {
-        const val SDK_LIBRARY = "amplitude-flutter"
-        const val SDK_VERSION = BuildConfig.SDK_VERSION
-    }
-
     override fun execute(event: BaseEvent): BaseEvent? {
-        event.library = "$SDK_LIBRARY/$SDK_VERSION"
+        event.library = library
         return super.execute(event)
     }
 }

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '10.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,10 @@
 PODS:
-  - Amplitude (8.16.1)
   - amplitude_flutter (0.0.1):
-    - Amplitude (= 8.16.1)
+    - AmplitudeSwift (~> 1.0.0)
     - Flutter
+  - AmplitudeSwift (1.0.0):
+    - AnalyticsConnector (~> 1.0.1)
+  - AnalyticsConnector (1.0.3)
   - Flutter (1.0.0)
 
 DEPENDENCIES:
@@ -11,7 +13,8 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - Amplitude
+    - AmplitudeSwift
+    - AnalyticsConnector
 
 EXTERNAL SOURCES:
   amplitude_flutter:
@@ -20,10 +23,11 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  Amplitude: ef9ed339ddd33c9183edf63fa4bbaa86cf873321
-  amplitude_flutter: 8ddb231989e68ed8c005c838d7fc59edbca09833
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  amplitude_flutter: 16812bda98a0de430b0021dbd59648c84b76f9ed
+  AmplitudeSwift: 17755f7599198721c32e26b884423759c2daec7d
+  AnalyticsConnector: a53214d38ae22734c6266106c0492b37832633a9
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
 
-PODFILE CHECKSUM: fe0e1ee7f3d1f7d00b11b474b62dd62134535aea
+PODFILE CHECKSUM: cc1f88378b4bfcf93a6ce00d2c587857c6008d3b
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.1

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -215,12 +215,14 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Amplitude/Amplitude.framework",
+				"${BUILT_PRODUCTS_DIR}/AmplitudeSwift/AmplitudeSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/AnalyticsConnector/AnalyticsConnector.framework",
 				"${BUILT_PRODUCTS_DIR}/amplitude_flutter/amplitude_flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Amplitude.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AmplitudeSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AnalyticsConnector.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/amplitude_flutter.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/.swiftlint.yml
+++ b/ios/.swiftlint.yml
@@ -1,0 +1,21 @@
+disabled_rules:
+  - file_length
+  - line_length
+  - function_body_length
+  - type_body_length
+  - trailing_comma
+  - opening_brace
+  - todo
+  - cyclomatic_complexity
+identifier_name:
+  allowed_symbols: "_"
+  min_length: 1
+nesting:
+  type_level:
+    warning: 3
+    error: 6
+  function_level:
+    warning: 5
+    error: 10
+excluded:
+  - Examples

--- a/ios/Classes/FlutterLibraryPlugin.swift
+++ b/ios/Classes/FlutterLibraryPlugin.swift
@@ -1,0 +1,18 @@
+import Foundation
+import AmplitudeSwift
+
+class FlutterLibraryPlugin: BeforePlugin {
+    static let sdkLibrary = "amplitude-flutter"
+    // Version is managed automatically by semantic-release in release.config.js, please don't change it manually
+    static let sdkVersion = "4.0.0-beta.0"
+
+    override func setup(amplitude: Amplitude) {
+        super.setup(amplitude: amplitude)
+    }
+
+    override func execute(event: BaseEvent) -> BaseEvent? {
+        event.library = "\(FlutterLibraryPlugin.sdkLibrary)/\(FlutterLibraryPlugin.sdkVersion)"
+
+        return event
+    }
+}

--- a/ios/Classes/FlutterLibraryPlugin.swift
+++ b/ios/Classes/FlutterLibraryPlugin.swift
@@ -2,12 +2,14 @@ import Foundation
 import AmplitudeSwift
 
 class FlutterLibraryPlugin: BeforePlugin {
-    static let sdkLibrary = "amplitude-flutter"
-    // Version is managed automatically by semantic-release in release.config.js, please don't change it manually
-    static let sdkVersion = "4.0.0-beta.0"
+    let library: String
+
+    init(library: String) {
+        self.library = library
+    }
 
     override func execute(event: BaseEvent) -> BaseEvent? {
-        event.library = "\(FlutterLibraryPlugin.sdkLibrary)/\(FlutterLibraryPlugin.sdkVersion)"
+        event.library = library
 
         return event
     }

--- a/ios/Classes/FlutterLibraryPlugin.swift
+++ b/ios/Classes/FlutterLibraryPlugin.swift
@@ -6,10 +6,6 @@ class FlutterLibraryPlugin: BeforePlugin {
     // Version is managed automatically by semantic-release in release.config.js, please don't change it manually
     static let sdkVersion = "4.0.0-beta.0"
 
-    override func setup(amplitude: Amplitude) {
-        super.setup(amplitude: amplitude)
-    }
-
     override func execute(event: BaseEvent) -> BaseEvent? {
         event.library = "\(FlutterLibraryPlugin.sdkLibrary)/\(FlutterLibraryPlugin.sdkVersion)"
 

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -17,13 +17,12 @@ import AmplitudeSwift
     // swiftlint:disable cyclomatic_complexity
     // swiftlint:disable function_body_length
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        guard let args = call.arguments as? [String: Any] else {
-            print("\(call.method) called but call.arguments type casting failed.")
-            return
-        }
-
         switch call.method {
         case "init":
+            guard let args = call.arguments as? [String: Any] else {
+                print("\(call.method) called but call.arguments type casting failed.")
+                return
+            }
 
             do {
                 amplitude = Amplitude(configuration: try getConfiguration(args: args))
@@ -43,6 +42,11 @@ import AmplitudeSwift
             result("init called..")
 
         case "track":
+            guard let args = call.arguments as? [String: Any] else {
+                print("\(call.method) called but call.arguments type casting failed.")
+                return
+            }
+
             do {
                 let event = try getEvent(args: args)
                 amplitude?.track(event: event)
@@ -54,6 +58,11 @@ import AmplitudeSwift
             }
 
         case "identify":
+            guard let args = call.arguments as? [String: Any] else {
+                print("\(call.method) called but call.arguments type casting failed.")
+                return
+            }
+
             do {
                 let event = try getEvent(args: args)
                 amplitude?.track(event: event)
@@ -65,6 +74,11 @@ import AmplitudeSwift
             }
 
         case "groupIdentify":
+            guard let args = call.arguments as? [String: Any] else {
+                print("\(call.method) called but call.arguments type casting failed.")
+                return
+            }
+
             do {
                 let event = try getEvent(args: args)
                 amplitude?.track(event: event)
@@ -76,6 +90,11 @@ import AmplitudeSwift
             }
 
         case "setGroup":
+            guard let args = call.arguments as? [String: Any] else {
+                print("\(call.method) called but call.arguments type casting failed.")
+                return
+            }
+
             do {
                 let event = try getEvent(args: args)
                 amplitude?.track(event: event)
@@ -87,6 +106,11 @@ import AmplitudeSwift
             }
 
         case "revenue":
+            guard let args = call.arguments as? [String: Any] else {
+                print("\(call.method) called but call.arguments type casting failed.")
+                return
+            }
+
             do {
                 let event = try getEvent(args: args)
                 amplitude?.track(event: event)
@@ -98,6 +122,11 @@ import AmplitudeSwift
             }
 
         case "setUserId":
+            guard let args = call.arguments as? [String: Any] else {
+                print("\(call.method) called but call.arguments type casting failed.")
+                return
+            }
+
             guard let userId = args["setUserId"] as? String else {
                 amplitude?.logger?.warn(message: "setUserId type casting to String failed.")
                 return
@@ -108,6 +137,11 @@ import AmplitudeSwift
             result("serUserId called..")
 
         case "setDeviceId":
+            guard let args = call.arguments as? [String: Any] else {
+                print("\(call.method) called but call.arguments type casting failed.")
+                return
+            }
+            
             guard let deviceId = args["setDeviceId"] as? String else {
                 amplitude?.logger?.warn(message: "setDeviceId type casting to String failed.")
                 return

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -27,11 +27,11 @@ import AmplitudeSwift
             }
 
             // Set library
-            guard let library = args["library"] as? String else {
-                amplitude?.logger?.warn(message: "Failed to set library.")
-                return
-            }
-            amplitude?.add(plugin: FlutterLibraryPlugin(library: library))
+            amplitude?.add(
+                plugin: FlutterLibraryPlugin(
+                    library: args["library"] as? String ?? "amplitude-flutter/unknown"
+                )
+            )
 
             amplitude?.logger?.debug(message: "Amplitude has been successfully initialized.")
 

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -141,7 +141,6 @@ import AmplitudeSwift
                 print("\(call.method) called but call.arguments type casting failed.")
                 return
             }
-            
             guard let deviceId = args["setDeviceId"] as? String else {
                 amplitude?.logger?.warn(message: "setDeviceId type casting to String failed.")
                 return
@@ -396,7 +395,6 @@ import AmplitudeSwift
         case apiKeyNotFound
         case eventTypeNotFound
     }
-
     // swiftlint:enable cyclomatic_complexity
     // swiftlint:enable function_body_length
 }

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -27,7 +27,7 @@ import AmplitudeSwift
             }
 
             // Set library
-            amplitude?.add(plugin: FlutterLibraryPlugin())
+            amplitude?.add(plugin: FlutterLibraryPlugin(library: args["library"] as! String))
 
             amplitude?.logger?.debug(message: "Amplitude has been successfully initialized.")
 

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -35,7 +35,7 @@ import AmplitudeSwift
 
             result("init called..")
 
-        case "track":
+        case "track", "identify", "groupIdentify", "setGroup", "revenue":
             guard let args = call.arguments as? [String: Any] else {
                 print("\(call.method) called but call.arguments type casting failed.")
                 return
@@ -44,75 +44,11 @@ import AmplitudeSwift
             do {
                 let event = try getEvent(args: args)
                 amplitude?.track(event: event)
-                amplitude?.logger?.debug(message: "Track event: \(String(describing: call.arguments))")
+                amplitude?.logger?.debug(message: "Track \(call.method) event: \(String(describing: call.arguments))")
 
-                result("track called..")
+                result("\(call.method) called..")
             } catch {
-                amplitude?.logger?.warn(message: "track called but failed.")
-            }
-
-        case "identify":
-            guard let args = call.arguments as? [String: Any] else {
-                print("\(call.method) called but call.arguments type casting failed.")
-                return
-            }
-
-            do {
-                let event = try getEvent(args: args)
-                amplitude?.track(event: event)
-                amplitude?.logger?.debug(message: "Track identify event: \(String(describing: call.arguments))")
-
-                result("identify called..")
-            } catch {
-                amplitude?.logger?.warn(message: "identify called but failed.")
-            }
-
-        case "groupIdentify":
-            guard let args = call.arguments as? [String: Any] else {
-                print("\(call.method) called but call.arguments type casting failed.")
-                return
-            }
-
-            do {
-                let event = try getEvent(args: args)
-                amplitude?.track(event: event)
-                amplitude?.logger?.debug(message: "Track group identify event: \(String(describing: call.arguments))")
-
-                result("groupIdentify called..")
-            } catch {
-                amplitude?.logger?.warn(message: "groupIdentify called but failed.")
-            }
-
-        case "setGroup":
-            guard let args = call.arguments as? [String: Any] else {
-                print("\(call.method) called but call.arguments type casting failed.")
-                return
-            }
-
-            do {
-                let event = try getEvent(args: args)
-                amplitude?.track(event: event)
-                amplitude?.logger?.debug(message: "Track set group event: \(String(describing: call.arguments))")
-
-                result("setGroup called..")
-            } catch {
-                amplitude?.logger?.warn(message: "setGroup called but failed.")
-            }
-
-        case "revenue":
-            guard let args = call.arguments as? [String: Any] else {
-                print("\(call.method) called but call.arguments type casting failed.")
-                return
-            }
-
-            do {
-                let event = try getEvent(args: args)
-                amplitude?.track(event: event)
-                amplitude?.logger?.debug(message: "Track revenue event: \(String(describing: call.arguments))")
-
-                result("revenue called..")
-            } catch {
-                amplitude?.logger?.warn(message: "revenue called but failed.")
+                amplitude?.logger?.warn(message: "\(call.method) called but failed.")
             }
 
         case "setUserId":

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -2,9 +2,7 @@ import Flutter
 import UIKit
 import AmplitudeSwift
 
-// swiftlint:disable type_body_length
 @objc public class SwiftAmplitudeFlutterPlugin: NSObject, FlutterPlugin {
-// swiftlint:enable type_body_length
     var amplitude: Amplitude?
     static let methodChannelName = "amplitude_flutter"
 
@@ -14,8 +12,6 @@ import AmplitudeSwift
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
 
-    // swiftlint:disable cyclomatic_complexity
-    // swiftlint:disable function_body_length
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "init":
@@ -35,9 +31,7 @@ import AmplitudeSwift
 
             amplitude?.logger?.debug(message: "Amplitude has been successfully initialized.")
 
-            // swiftlint:disable todo
             // TODO(xinyi): add app lifecycle events
-            // swiftlint:enable todo
 
             result("init called..")
 
@@ -352,6 +346,63 @@ import AmplitudeSwift
         if let locationLng = args["location_lng"] as? Double {
             event.locationLng = locationLng
         }
+        if let appVersion = args["app_version"] as? String {
+            event.appVersion = appVersion
+        }
+        if let versionName = args["version_name"] as? String {
+            event.versionName = versionName
+        }
+        if let platform = args["platform"] as? String {
+            event.platform = platform
+        }
+        if let osName = args["os_name"] as? String {
+            event.osName = osName
+        }
+        if let osVersion = args["os_version"] as? String {
+            event.osVersion = osVersion
+        }
+        if let deviceBrand = args["device_brand"] as? String {
+            event.deviceBrand = deviceBrand
+        }
+        if let deviceManufacturer = args["device_manufacturer"] as? String {
+            event.deviceManufacturer = deviceManufacturer
+        }
+        if let deviceModel = args["device_model"] as? String {
+            event.deviceModel = deviceModel
+        }
+        if let carrier = args["carrier"] as? String {
+            event.carrier = carrier
+        }
+        if let country = args["country"] as? String {
+            event.country = country
+        }
+        if let region = args["region"] as? String {
+            event.region = region
+        }
+        if let city = args["city"] as? String {
+            event.city = city
+        }
+        if let dma = args["dma"] as? String {
+            event.dma = dma
+        }
+        if let idfa = args["idfa"] as? String {
+            event.idfa = idfa
+        }
+        if let idfv = args["idfv"] as? String {
+            event.idfv = idfv
+        }
+        if let adid = args["adid"] as? String {
+            event.adid = adid
+        }
+        if let language = args["language"] as? String {
+            event.language = language
+        }
+        if let library = args["library"] as? String {
+            event.library = library
+        }
+        if let ip = args["ip"] as? String {
+            event.ip = ip
+        }
         if let planMap = args["plan"] as? [String: Any] {
             event.plan = Plan(
                 branch: planMap["branch"] as? String,
@@ -395,6 +446,4 @@ import AmplitudeSwift
         case apiKeyNotFound
         case eventTypeNotFound
     }
-    // swiftlint:enable cyclomatic_complexity
-    // swiftlint:enable function_body_length
 }

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -27,7 +27,11 @@ import AmplitudeSwift
             }
 
             // Set library
-            amplitude?.add(plugin: FlutterLibraryPlugin(library: args["library"] as! String))
+            guard let library = args["library"] as? String else {
+                amplitude?.logger?.warn(message: "Failed to set library.")
+                return
+            }
+            amplitude?.add(plugin: FlutterLibraryPlugin(library: library))
 
             amplitude?.logger?.debug(message: "Amplitude has been successfully initialized.")
 

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -18,10 +18,12 @@ import AmplitudeSwift
 
                 amplitude = Amplitude(configuration: getConfiguration(call: call))
 
-                // TODO(xinyi): add library plugin
+                // Set library
+                amplitude?.add(plugin: FlutterLibraryPlugin())
+
                 amplitude?.logger?.debug(message: "Amplitude has been successfully initialized.")
 
-                // TODO(xinyi): check app lifecycle events
+                // TODO(xinyi): add app lifecycle events
 
                 result("init called..")
 
@@ -171,7 +173,7 @@ import AmplitudeSwift
         case "debug":
             return .DEBUG
         default:
-            return .WARN
+            return .DEBUG
         }
     }
 

--- a/ios/amplitude_flutter.podspec
+++ b/ios/amplitude_flutter.podspec
@@ -1,9 +1,12 @@
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
+
+amplitude_version = "4.0.0-beta.0" # Version is managed automatically by semantic-release, please don't change it manually
+
 Pod::Spec.new do |s|
   s.name             = 'amplitude_flutter'
-  s.version          = '0.0.1'
+  s.version          = amplitude_version
   s.summary          = 'A new flutter plugin project.'
   s.homepage         = 'http://example.com'
   s.license          = { :file => '../LICENSE' }

--- a/ios/amplitude_flutter.podspec
+++ b/ios/amplitude_flutter.podspec
@@ -12,8 +12,8 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Amplitude', '8.16.1'
+  s.dependency 'AmplitudeSwift', '~> 1.0.0'
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '13.0'
 end
 

--- a/ios/amplitude_flutter.podspec
+++ b/ios/amplitude_flutter.podspec
@@ -1,12 +1,9 @@
 #
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
-
-amplitude_version = "4.0.0-beta.0" # Version is managed automatically by semantic-release, please don't change it manually
-
 Pod::Spec.new do |s|
   s.name             = 'amplitude_flutter'
-  s.version          = amplitude_version
+  s.version          = '0.0.1'
   s.summary          = 'A new flutter plugin project.'
   s.homepage         = 'http://example.com'
   s.license          = { :file => '../LICENSE' }

--- a/lib/configuration.dart
+++ b/lib/configuration.dart
@@ -93,6 +93,9 @@ class Configuration {
       'useAdvertisingIdForDeviceId': useAdvertisingIdForDeviceId,
       'useAppSetIdForDeviceId': useAppSetIdForDeviceId,
       'appVersion': appVersion,
+      // This field doesn't belong to Configuration
+      // Pass it for FlutterLibraryPlugin
+      'library': "${Constants.packageName}/${Constants.packageVersion}"
     };
   }
 }

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,4 +1,6 @@
 class Constants {
+  static const packageName = "amplitude-flutter";
+  static const packageVersion = "3.16.1";
   static const identify_event = "\$identify";
   static const group_identify_event = "\$groupidentify";
   static const revenue_event = "revenue_amount";

--- a/release.config.js
+++ b/release.config.js
@@ -77,6 +77,20 @@ module.exports = {
             ],
             "countMatches": true
             },
+            {
+                "files": ["ios/Classes/FlutterLibraryPlugin.swift"],
+                "from": "static let sdkVersion = \".*\"",
+                "to": "static let sdkVersion = \"${nextRelease.version}\"",
+                "results": [
+                  {
+                    "file": "ios/Classes/FlutterLibraryPlugin.swift",
+                    "hasChanged": true,
+                    "numMatches": 1,
+                    "numReplacements": 1
+                  }
+                ],
+                "countMatches": true
+            },
         ]
       }
     ],

--- a/release.config.js
+++ b/release.config.js
@@ -63,34 +63,6 @@ module.exports = {
             ],
             "countMatches": true
           },
-          {
-            "files": ["android/build.gradle"],
-            "from": "PUBLISH_VERSION = \'.*\'",
-            "to": "PUBLISH_VERSION = \'${nextRelease.version}\'",
-            "results": [
-                {
-                  "file": "android/build.gradle",
-                  "hasChanged": true,
-                  "numMatches": 1,
-                  "numReplacements": 1
-                }
-            ],
-            "countMatches": true
-            },
-            {
-                "files": ["ios/Classes/FlutterLibraryPlugin.swift"],
-                "from": "static let sdkVersion = \".*\"",
-                "to": "static let sdkVersion = \"${nextRelease.version}\"",
-                "results": [
-                  {
-                    "file": "ios/Classes/FlutterLibraryPlugin.swift",
-                    "hasChanged": true,
-                    "numMatches": 1,
-                    "numReplacements": 1
-                  }
-                ],
-                "countMatches": true
-            },
         ]
       }
     ],

--- a/test/amplitude_test.dart
+++ b/test/amplitude_test.dart
@@ -83,6 +83,9 @@ void main() {
     "useAdvertisingIdForDeviceId": false,
     "useAppSetIdForDeviceId": false,
     "appVersion": null,
+    // This field doesn't belong to Configuration
+    // Pass it for FlutterLibraryPlugin
+    "library": "${Constants.packageName}/${Constants.packageVersion}"
   };
   final testEvent = BaseEvent(eventType: "testEvent");
   final testEventMap = {


### PR DESCRIPTION
- Update iOS bridge file at `ios/Classes/SwiftAmplitudeFlutterPlugin.swift`
- App lifecycle events are not support in the pre-release version. Will have another ticket for it
- Add `swiftlint` to CI
- Don't have iOS native unit tests right now because the [one](https://github.com/amplitude/Amplitude-Flutter/blob/v4.x/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt) for Android should cover all cases where method channel goes wrong.
- Update set library logics by https://github.com/amplitude/Amplitude-Flutter/pull/176#discussion_r1514798327
  - Before
    - `release.config.js` has to change package version for Flutter, Android (BuildConfig.SDK_VERSION`) and Swift plugins separately
    - Android and Swift library plugins set library for every events
  - Now
    - `release.config.js` only need to change package version for Flutter
    - Flutter pass `library` along with configuration when `init`
    - Native sides read library and pass to library plugins
