### PR TITLE
feat: update to the latests native SDKs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Analyze
         run: flutter analyze --no-fatal-infos
 
-#      - name: Test
-#        run: flutter test
+      - name: Test
+        run: flutter test
 
       - name: Semantic Release --dry-run
         if: ${{ github.event.inputs.dryRun == 'true'}}

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -30,7 +30,7 @@ class _MyAppState extends State<MyApp> {
   late Amplitude analytics;
 
   initAnalytics() async {
-    await analytics.init();
+    await analytics.isBuilt;
 
     setMessage('Amplitude initialized');
   }

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:amplitude_flutter/amplitude.dart';
 import 'package:amplitude_flutter/configuration.dart';
 import 'package:amplitude_flutter/constants.dart';
+import 'package:amplitude_flutter/default_tracking.dart';
 import 'package:flutter/material.dart';
 
 import 'app_state.dart';
@@ -39,7 +40,12 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
     analytics = Amplitude(
-        Configuration(apiKey: widget.apiKey, logLevel: LogLevel.debug));
+        Configuration(
+            apiKey: widget.apiKey,
+            logLevel: LogLevel.debug,
+            defaultTracking: DefaultTrackingOptions.all()
+        )
+    );
     initAnalytics();
   }
 

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -12,26 +12,36 @@ import 'package:amplitude_flutter/events/group_identify_event.dart';
 class Amplitude {
   Configuration configuration;
   MethodChannel _channel = const MethodChannel("amplitude_flutter");
+  /// Whether the Amplitude instance has been successfully initialized
+  ///
+  /// ```
+  /// var amplitude = Amplitude(Configuration(apiKey: "apiKey"));
+  /// // If care about init complete
+  /// await amplitude.isBuilt;
+  /// ```
+  late Future<bool> isBuilt;
 
   /// Returns an Amplitude instance
   ///
-  /// Call `init()` to initialize underlying SDKs on native platforms
   /// ```
   /// var amplitude = Amplitude(Configuration(apiKey: "apiKey"));
-  /// await amplitude.init();
+  /// // If care about init complete
+  /// await amplitude.isBuilt;
   /// ```
-  Amplitude(this.configuration);
-
-  /// Initializes an Amplitude instance
-  ///
-  /// ```
-  /// var amplitude = Amplitude(Configuration(apiKey: "apiKey"));
-  /// await amplitude.init();
-  /// ```
-  Future<void> init([MethodChannel? methodChannel]) async {
+  Amplitude(this.configuration, [MethodChannel? methodChannel]){
     _channel = methodChannel ?? this._channel;
-    return await _channel.invokeMethod(
-        "init", this.configuration.toMap());
+    isBuilt = _init();
+  }
+
+  /// Private method to initialize and return a Future<bool>
+  Future<bool> _init() async {
+    try {
+      await _channel.invokeMethod("init", configuration.toMap());
+      return true; // Initialization successful
+    } catch (e) {
+      print("Error initializing Amplitude: $e");
+      return false; // Initialization failed
+    }
   }
 
   /// Tracks an event. Events are saved locally.

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -14,6 +14,12 @@ class Amplitude {
   MethodChannel _channel = const MethodChannel("amplitude_flutter");
 
   /// Returns an Amplitude instance
+  ///
+  /// Call `init()` to initialize underlying SDKs on native platforms
+  /// ```
+  /// var amplitude = Amplitude(Configuration(apiKey: "apiKey"));
+  /// await amplitude.init();
+  /// ```
   Amplitude(this.configuration);
 
   /// Initializes an Amplitude instance
@@ -184,14 +190,14 @@ class Amplitude {
     Map<String, String?> properties = {};
     properties["setDeviceId"] = deviceId;
 
-    await await _channel.invokeMethod("setDeviceId", properties);
+    return await _channel.invokeMethod("setDeviceId", properties);
   }
 
   /// Resets userId to "null" and deviceId to a random UUID.
   ///
   /// Note different devices on different platforms should have different device Ids.
   Future<void> reset() async {
-    await await _channel.invokeMethod("reset");
+    return await _channel.invokeMethod("reset");
   }
 
   /// Flush events in storage.

--- a/lib/configuration.dart
+++ b/lib/configuration.dart
@@ -2,12 +2,6 @@ import 'constants.dart';
 import 'tracking_options.dart';
 import 'default_tracking.dart';
 
-/// Configuration for Amplitude instance.
-/// 
-/// Before initializing Amplitude instance, create a Configuration instance
-/// with your desired configuration and pass it to the Amplitude instance.
-/// Note the Configuration is immutable (cannot be changed) after being passed to Amplitude.init()
-/// `optOut` can be changed later by calling `setOptOut()`.
 class Configuration {
   String apiKey;
   int flushQueueSize;
@@ -40,6 +34,14 @@ class Configuration {
   bool useAppSetIdForDeviceId;
   /// Web specific
   String? appVersion;
+
+  /// Configuration for Amplitude instance.
+  ///
+  /// Before initializing Amplitude instance, create a Configuration instance
+  /// with your desired configuration and pass it to the Amplitude instance.
+  ///
+  /// Note the Configuration is immutable (cannot be changed) after being passed to Amplitude
+  /// `optOut` can be changed later by calling `setOptOut()`.
   Configuration({
     required this.apiKey,
     this.flushQueueSize = Constants.flushQueueSize,

--- a/release.config.js
+++ b/release.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   "branches": [
-    "main"
+    "main",
+    { "name": "beta", "prerelease": true },
   ],
   "tagFormat": ["v${version}"],
   "plugins": [

--- a/test/amplitude_test.dart
+++ b/test/amplitude_test.dart
@@ -100,8 +100,8 @@ void main() {
     mockChannel = MockMethodChannel();
     when(mockChannel.invokeListMethod("init", any))
         .thenAnswer((_) async => null);
-    amplitude = Amplitude(testConfiguration);
-    await amplitude.init(mockChannel);
+    amplitude = Amplitude(testConfiguration, mockChannel);
+    await amplitude.isBuilt;
   });
 
   test("Should init and track call MethodChannel", () async {


### PR DESCRIPTION
- Enable flutter test when on release
- Fix some nits at Flutter at `lib/xxx.dart`
- Enable pre-release on beta branch at `release.config.js` which is triggered when the Release (release.yml) github actions is triggered

After this PR is merged to `v4.x`, do the following to pre-release
1. Create a `beta` branch based on `v4.x`
2. Manually run github actions Release with a dry run to make sure the correct semantic version will be set
3. Manually run github actions Release without a dry run to pre-release. This is trigger `publish.yml` to publish the package to pub.dev 
Here is the [test](https://amplitude.atlassian.net/browse/AMP-94599?focusedCommentId=242548) I ran on the forked repo.

Note that it's not as flexible as [feature-branch-prerelease.yml](https://github.com/amplitude/Amplitude-TypeScript/blob/main/.github/workflows/feature-branch-prerelease.yml) of Browser SDK as it does not support selecting the prerelease branch but fix to beta branch due to the limitation of [semantic-release](https://semantic-release.gitbook.io/semantic-release/) while Browser SDK uses [lerna](https://github.com/amplitude/Amplitude-TypeScript/blob/e8216bc65399106214cc5c0ae4d7e8d053029af4/.github/workflows/publish-v2.yml#L88-L95). 