### PR TITLE
ci: update dry run string

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,16 @@
 name: Publish to pub.dev
 
 on:
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Do a dry run to preview instead of a real publish'
+        type: choice
+        required: true
+        default: 'true'
+        options:
+          - 'true'
+          - 'false'
 
 jobs:
   publish:
@@ -34,5 +41,10 @@ jobs:
       - name: Check Flutter version
         run: flutter --version
 
+      - name: Publish to pub.dev --dry-run
+        if: ${{ github.event.inputs.dryRun == 'false' }}
+        run: flutter pub publish --dry-run
+
       - name: Publish to pub.dev
+        if: ${{ github.event.inputs.dryRun == 'false' }}
         run: flutter pub publish --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,10 +7,10 @@ on:
         description: 'Do a dry run to preview instead of a real publish'
         type: choice
         required: true
-        default: 'true'
+        default: 'dry-run'
         options:
-          - 'true'
-          - 'false'
+          - 'dry-run'
+          - 'publish'
 
 jobs:
   publish:
@@ -42,9 +42,9 @@ jobs:
         run: flutter --version
 
       - name: Publish to pub.dev --dry-run
-        if: ${{ github.event.inputs.dryRun == 'true' }}
+        if: ${{ github.event.inputs.dryRun == 'dry-run' }}
         run: flutter pub publish --dry-run
 
       - name: Publish to pub.dev
-        if: ${{ github.event.inputs.dryRun == 'false' }}
+        if: ${{ github.event.inputs.dryRun == 'publish' }}
         run: flutter pub publish --force

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
         run: flutter --version
 
       - name: Publish to pub.dev --dry-run
-        if: ${{ github.event.inputs.dryRun == 'false' }}
+        if: ${{ github.event.inputs.dryRun == 'true' }}
         run: flutter pub publish --dry-run
 
       - name: Publish to pub.dev

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,9 @@
 name: Publish to pub.dev
 
 on:
-  workflow_dispatch:
-    inputs:
-      dryRun:
-        description: 'Do a dry run to preview instead of a real publish'
-        type: choice
-        required: true
-        default: 'dry-run'
-        options:
-          - 'dry-run'
-          - 'publish'
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   publish:
@@ -41,10 +34,5 @@ jobs:
       - name: Check Flutter version
         run: flutter --version
 
-      - name: Publish to pub.dev --dry-run
-        if: ${{ github.event.inputs.dryRun == 'dry-run' }}
-        run: flutter pub publish --dry-run
-
       - name: Publish to pub.dev
-        if: ${{ github.event.inputs.dryRun == 'publish' }}
         run: flutter pub publish --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,10 @@ on:
         description: 'Do a dry run to preview instead of a real release'
         type: choice
         required: true
-        default: 'true'
+        default: 'dry-run'
         options:
-          - 'true'
-          - 'false'
+          - 'dry-run'
+          - 'release'
 
 jobs:
   authorize:
@@ -53,7 +53,7 @@ jobs:
         run: flutter test
 
       - name: Semantic Release --dry-run
-        if: ${{ github.event.inputs.dryRun == 'true'}}
+        if: ${{ github.event.inputs.dryRun == 'dry-run'}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: amplitude-sdk-bot
@@ -71,7 +71,7 @@ jobs:
           semantic-release --dry-run
 
       - name: Semantic Release
-        if: ${{ github.event.inputs.dryRun == 'false'}}
+        if: ${{ github.event.inputs.dryRun == 'release'}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: amplitude-sdk-bot


### PR DESCRIPTION
- Make dry run more explicit in the option names https://github.com/amplitude/Amplitude-Flutter/pull/180#discussion_r1522234541

A stable version release will trigger publish automatically by https://github.com/amplitude/Amplitude-Flutter/blob/cf63a68f7f9fa3ae8315a1806edb5f7e6d02c8ad/.github/workflows/publish.yml#L6

To publish a beta version
- Checkout the latest beta branch
- Run `flutter pub publish --dry-run`
- If everything looks good, run without dry run to publish `flutter pub publish`
- Check https://pub.dev/packages/amplitude_flutter
