### PR TITLE
feat: enable app installed & updated events for iOS

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
   - amplitude_flutter (0.0.1):
-    - AmplitudeSwift (~> 1.0.0)
+    - AmplitudeSwift (~> 1.4.4)
     - Flutter
-  - AmplitudeSwift (1.0.0):
+  - AmplitudeSwift (1.4.4):
     - AnalyticsConnector (~> 1.0.1)
   - AnalyticsConnector (1.0.3)
   - Flutter (1.0.0)
@@ -23,8 +23,8 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  amplitude_flutter: 16812bda98a0de430b0021dbd59648c84b76f9ed
-  AmplitudeSwift: 17755f7599198721c32e26b884423759c2daec7d
+  amplitude_flutter: 490e6b7e89b4dcac86dced0cd85e8a477419f751
+  AmplitudeSwift: 13725c3313c2e2cac30836dc2c973d3883baabef
   AnalyticsConnector: a53214d38ae22734c6266106c0492b37832633a9
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
 

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -35,7 +35,9 @@ import AmplitudeSwift
 
             amplitude?.logger?.debug(message: "Amplitude has been successfully initialized.")
 
-            // TODO(xinyi): add app lifecycle events
+            // Track DET app lifecycle: application installed and updated events
+            let utils = DefaultEventUtils(amplitude: amplitude!)
+            utils.trackAppUpdatedInstalledEvent()
 
             result("init called..")
 

--- a/ios/amplitude_flutter.podspec
+++ b/ios/amplitude_flutter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AmplitudeSwift', '~> 1.0.0'
+  s.dependency 'AmplitudeSwift', '~> 1.4.4' # enable default app lifecycle events
 
   s.ios.deployment_target = '13.0'
 end


### PR DESCRIPTION
This PR depends on https://github.com/amplitude/Amplitude-Swift/pull/150. Do **NOT** merge it until Amplitude-Swift is updated. 

- Application open & background events work out of box
- This PR enables application installed & updated events
- All app lifecycles events should be enabled after this PR
- Specify the Flutter iOS plugin to use `Amplitude-Swift v1.4.4` and above in `podspec` file which is the minimum version to include the changes in https://github.com/amplitude/Amplitude-Swift/pull/150

https://amplitude.atlassian.net/browse/AMP-95568 Test event links are in the ticket description.