### PR TITLE
chore: remove screenViews

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -175,7 +175,9 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 sessions = (map["sessions"] as? Boolean) ?: true,
                 appLifecycles = (map["appLifecycles"] as? Boolean) ?: false,
                 deepLinks = (map["deepLinks"] as? Boolean) ?: false,
-                screenViews = (map["screenViews"] as? Boolean) ?: false
+                // Set false to disable screenViews on Android
+                // screenViews is implemented in Flutter
+                screenViews = false
             )
         }
         call.argument<Map<String, Any>>("trackingOptions")?.let { map ->

--- a/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt
@@ -45,7 +45,6 @@ class AmplitudeFlutterPluginTest {
             "defaultTracking" to JSONObject(mapOf(
                 "sessions" to true,
                 "appLifecycles" to false,
-                "screenViews" to false,
                 "deepLinks" to false,
                 "attribution" to true,
                 "pageViews" to true,

--- a/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/ios/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -167,7 +167,9 @@ import AmplitudeSwift
         if let defaultTrackingDict = args["defaultTracking"] as? [String: Bool] {
             let sessions = defaultTrackingDict["sessions"] ?? true
             let appLifecycles = defaultTrackingDict["appLifecycles"] ?? false
-            let screenViews = defaultTrackingDict["screenViews"] ?? false
+            // Set false to disable screenViews on iOS
+            // screenViews is implemented in Flutter
+            let screenViews = false
             configuration.defaultTracking = DefaultTrackingOptions(
                 sessions: sessions,
                 appLifecycles: appLifecycles,

--- a/lib/default_tracking.dart
+++ b/lib/default_tracking.dart
@@ -10,8 +10,9 @@ class DefaultTrackingOptions {
   final bool sessions;
   /// Mobile (iOS and Android) specific
   final bool appLifecycles;
-  /// Mobile (iOS and Android) specific
-  final bool screenViews;
+  // TODO(xinyi): implement screenViews in Flutter
+  // /// Mobile (iOS and Android) specific
+  // final bool screenViews;
   /// Android specific
   final bool deepLinks;
   /// Web specific
@@ -26,7 +27,7 @@ class DefaultTrackingOptions {
   const DefaultTrackingOptions({
     this.sessions = true,
     this.appLifecycles = false,
-    this.screenViews = false,
+    // this.screenViews = false,
     this.deepLinks = false,
     this.attribution = true,
     this.pageViews = true,
@@ -41,7 +42,7 @@ class DefaultTrackingOptions {
     return const DefaultTrackingOptions(
       sessions: true,
         appLifecycles: true, 
-        screenViews: true,
+        // screenViews: true,
         deepLinks: true,
         attribution: true,
         pageViews: true,
@@ -55,7 +56,7 @@ class DefaultTrackingOptions {
     return const DefaultTrackingOptions(
       sessions: false,
         appLifecycles: false, 
-        screenViews: false,
+        // screenViews: false,
         deepLinks: false,
         attribution: false,
         pageViews: false,
@@ -68,7 +69,6 @@ class DefaultTrackingOptions {
     return {
       'sessions': sessions,
       'appLifecycles': appLifecycles,
-      'screenViews': screenViews,
       'deepLinks': deepLinks,
       'attribution': attribution,
       'pageViews': pageViews,

--- a/test/amplitude_test.dart
+++ b/test/amplitude_test.dart
@@ -47,7 +47,6 @@ void main() {
     'defaultTracking': {
       'sessions': true,
       'appLifecycles': false,
-      'screenViews': false,
       'deepLinks': false,
       'attribution': true,
       'pageViews': true,

--- a/test/default_tracking_test.dart
+++ b/test/default_tracking_test.dart
@@ -8,7 +8,7 @@ void main(){
 
       expect(defaultTrackingOptions.sessions, true);
       expect(defaultTrackingOptions.appLifecycles, true);
-      expect(defaultTrackingOptions.screenViews, true);
+      // expect(defaultTrackingOptions.screenViews, true);
       expect(defaultTrackingOptions.deepLinks, true);
       expect(defaultTrackingOptions.attribution, true);
       expect(defaultTrackingOptions.pageViews, true);
@@ -21,7 +21,7 @@ void main(){
 
       expect(defaultTrackingOptions.sessions, false);
       expect(defaultTrackingOptions.appLifecycles, false);
-      expect(defaultTrackingOptions.screenViews, false);
+      // expect(defaultTrackingOptions.screenViews, false);
       expect(defaultTrackingOptions.deepLinks, false);
       expect(defaultTrackingOptions.attribution, false);
       expect(defaultTrackingOptions.pageViews, false);


### PR DESCRIPTION
Screen views tracking should be implemented in Flutter.
- Comment `config.defaultTracking.screenViews`
- Remove `screenViews` in the map passed to native platforms via method channel
- Set `config.defaultTracking.screenViews` to false in iOS and Android plugins to disable native platform screen views tracking