### PR TITLE
fix: Adding underlying library version to library field

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/FlutterLibraryPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/FlutterLibraryPlugin.kt
@@ -9,7 +9,11 @@ class FlutterLibraryPlugin(val library: String): Plugin {
     override lateinit var amplitude: Amplitude
 
     override fun execute(event: BaseEvent): BaseEvent? {
-        event.library = library
+        if (event.library == null) {
+            event.library = library
+        } else {
+            event.library = "$library_${event.library}"
+        }
         return super.execute(event)
     }
 }

--- a/ios/Classes/FlutterLibraryPlugin.swift
+++ b/ios/Classes/FlutterLibraryPlugin.swift
@@ -9,8 +9,11 @@ class FlutterLibraryPlugin: BeforePlugin {
     }
 
     override func execute(event: BaseEvent) -> BaseEvent? {
-        event.library = library
-
+        if let eventLibrary = event.library {
+            event.library = "\(library)_\(eventLibrary)"
+        } else {
+            event.library = library
+        }
         return event
     }
 }

--- a/ios/amplitude_flutter.podspec
+++ b/ios/amplitude_flutter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AmplitudeSwift', '~> 1.6' # enable default app lifecycle events
+  s.dependency 'AmplitudeSwift', '~> 1.6'
 
   s.ios.deployment_target = '13.0'
 end

--- a/ios/amplitude_flutter.podspec
+++ b/ios/amplitude_flutter.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'AmplitudeSwift', '~> 1.4.4' # enable default app lifecycle events
+  s.dependency 'AmplitudeSwift', '~> 1.6' # enable default app lifecycle events
 
   s.ios.deployment_target = '13.0'
 end


### PR DESCRIPTION
Setting min iOS SDK to 1.6 and appending underlying SDK library to library version