### PR TITLE
Set `jvmTarget` to `1.8`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,9 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"


### PR DESCRIPTION
Closes #163 .

Setting the `jvmTarget` to `1.8` allows projects with higher Kotlin versions to still use this package without running into JVM incompatibility issues.