### PR TITLE
fix: solve issue that sdk can not be compiled on android platform

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
     // Condition for namespace compatibility in AGP 8
     if (project.android.hasProperty("namespace")) {
         namespace 'com.amplitude.amplitude_flutter'


### PR DESCRIPTION
## Summary

1. Flutter app project using Amplitude-Flutter cannot be compiled with `flutter bulid apk` command on build machine that Flutter 3.24.0 or later is installed.
2. Cause of problem is Flutter 3.24.0 upgrades AndroidX dependencies that requires compileSdkVersion 31. (Amplitude-Flutter use 28 as compileSdkVersion)
3. It cannot be fixed with modification on flutter app project only.
4. It can be fixed with modification on flutter app project and Amplitude-Flutter both. (Set compileSdkVersion to 31 or later)
5. This pull request set Amplitude-Flutter's compileSdkVersion to 31.

## Why?

Flutter app project using Amplitude-Flutter cannot be compiled with `flutter bulid apk` command on build machine that Flutter 3.24.0 or later is installed.
Because on Flutter 3.24.0, it upgrades AndroidX dependencies that requires compileSdkVersion 31 but Amplitude-Flutter use 28.
To fix this issue Amplitude-Flutter should change compileSdkVersion to 31 or later.
Change compileSdkVersion to 31 or later on flutter app project do not fix the problem.

## How to reproduce problem?

Run command below.

```sh
flutter upgrade
flutter create test_amplitude --platform android
cd test_amplitude
flutter pub add amplitude_flutter
flutter pub get
flutter build apk
```

Then below error is occurred

```sh
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':amplitude_flutter:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.tasks.VerifyLibraryResourcesTask$Action
   > Android resource linking failed
     ERROR:/{YOUR_PATH}/test_amplitude/build/amplitude_flutter/intermediates/merged_res/release/values/values.xml:206: AAPT: error: resource android:attr/lStar not found.


* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 16s
Running Gradle task 'assembleRelease'...                           17.4s
Gradle task assembleRelease failed with exit code 1
```

## Cause of problem

Flutter 3.24.0 upgrades AndroidX dependencies that requires compileSdkVersion 31.
Refer comment from Flutter issue https://github.com/flutter/flutter/issues/153281#issuecomment-2291700217.

## Solution

Update Amplitude-Flutter's compileSdkVersion to 31.