### PR TITLE
chore(example): migrate to flutter 3

### DIFF
--- a/example/lib/app_state.dart
+++ b/example/lib/app_state.dart
@@ -1,5 +1,4 @@
 import 'package:amplitude_flutter/amplitude.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class AppState extends InheritedWidget {

--- a/example/lib/deviceid_sessionid.dart
+++ b/example/lib/deviceid_sessionid.dart
@@ -13,7 +13,7 @@ class _DeviceIdSessionIdState extends State<DeviceIdSessionId> {
       children: [
         Row(
           children: [
-            Text('Device Id', style: Theme.of(context).textTheme.headline5),
+            Text('Device Id', style: Theme.of(context).textTheme.headlineSmall),
           ],
         ),
         Row(
@@ -28,7 +28,7 @@ class _DeviceIdSessionIdState extends State<DeviceIdSessionId> {
         ),
         Row(
           children: [
-            Text('Session Id', style: Theme.of(context).textTheme.headline5),
+            Text('Session Id', style: Theme.of(context).textTheme.headlineSmall),
           ],
         ),
         Row(children: [

--- a/example/lib/event_form.dart
+++ b/example/lib/event_form.dart
@@ -22,7 +22,7 @@ class _EventFormState extends State<EventForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Event', style: Theme.of(context).textTheme.headline5),
+        Text('Event', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         TextField(
             decoration: InputDecoration(

--- a/example/lib/flush_thresholds_form.dart
+++ b/example/lib/flush_thresholds_form.dart
@@ -39,7 +39,7 @@ class _FlushThresholdFormState extends State<FlushThresholdForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Flush Intervals', style: Theme.of(context).textTheme.headline5),
+        Text('Flush Intervals', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         TextField(
             decoration: InputDecoration(

--- a/example/lib/group_form.dart
+++ b/example/lib/group_form.dart
@@ -29,7 +29,7 @@ class _GroupFormState extends State<GroupForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Group / Account', style: Theme.of(context).textTheme.headline5),
+        Text('Group / Account', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         Row(children: <Widget>[
           Expanded(

--- a/example/lib/group_identify_form.dart
+++ b/example/lib/group_identify_form.dart
@@ -41,7 +41,7 @@ class _GroupIdentifyFormState extends State<GroupIdentifyForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Group Identify', style: Theme.of(context).textTheme.headline5),
+        Text('Group Identify', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         Row(children: <Widget>[
           Expanded(

--- a/example/lib/identify_form.dart
+++ b/example/lib/identify_form.dart
@@ -35,7 +35,7 @@ class _IdentifyFormState extends State<IdentifyForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Identify', style: Theme.of(context).textTheme.headline5),
+        Text('Identify', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         Row(children: <Widget>[
           Expanded(

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -112,7 +112,7 @@ class _MyAppState extends State<MyApp> {
                   child: const Text('Flush Events'),
                   onPressed: _flushEvents,
                 ),
-                Text(_message, style: Theme.of(context).textTheme.bodyText1)
+                Text(_message, style: Theme.of(context).textTheme.bodyLarge)
               ],
             ),
           ),

--- a/example/lib/revenue_form.dart
+++ b/example/lib/revenue_form.dart
@@ -38,7 +38,7 @@ class _RevenueFormState extends State<RevenueForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Revenue', style: Theme.of(context).textTheme.headline5),
+        Text('Revenue', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         TextField(
             decoration: dec.copyWith(labelText: 'Product Id'),

--- a/example/lib/user_id_form.dart
+++ b/example/lib/user_id_form.dart
@@ -19,7 +19,7 @@ class _UserIdFormState extends State<UserIdForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Current User Id', style: Theme.of(context).textTheme.headline5),
+        Text('Current User Id', style: Theme.of(context).textTheme.headlineSmall),
         FutureBuilder(
           future: AppState.of(context).analytics.getUserId(),
           builder: (BuildContext context, AsyncSnapshot<dynamic> snapshot) {
@@ -27,7 +27,7 @@ class _UserIdFormState extends State<UserIdForm> {
           },
         ),
         const SizedBox(height: 10),
-        Text('User Id', style: Theme.of(context).textTheme.headline5),
+        Text('User Id', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         new TextField(
             autocorrect: false,

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -87,38 +87,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.4"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.5"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.5"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -168,10 +192,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.2"
   vector_math:
     dependency: transitive
     description:
@@ -180,14 +204,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
+  vm_service:
     dependency: transitive
     description:
-      name: web
-      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
+      name: vm_service
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "14.2.5"
 sdks:
-  dart: ">=3.2.0-194.0.dev <4.0.0"
-  flutter: ">=2.0.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
Flutter 3 is released in May 2022 with some API deprecations. This PR update example app to use the update API to pass `flutter analyze`.