### PR TITLE
fix: add swift version in podspec

### DIFF
--- a/ios/amplitude_flutter.podspec
+++ b/ios/amplitude_flutter.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Amplitude', '8.18.0'
+  s.swift_version    = '4.1'
 
   s.ios.deployment_target = '10.0'
 end


### PR DESCRIPTION
# What's Changed

Added the `swift_version` to the Podspec to help developers with an `add-to-app` setup not run into the missing `SWIFT_VERSION` error when compiling.

# Rationale
When using this plugin on a project that is being compiled for the add-to-app approach in Flutter, developers will usually get this error:

```  
 - amplitude_flutter does not specify a Swift version and none of the targets (Runner) integrating it have the SWIFT_VERSION attribute set. Please contact the author or set the SWIFT_VERSION attribute in at least one of the targets that integrate this pod.
```

To fix this, developers have to go into their generated Podspec and add the `SWIFT_VERSION` environment variable for the build to work. This is not an ideal workflow.

By adding the Swift Version to the Podspec, builds compile without a hitch. 