### PR TITLE
chore: upgrade package:js min dependency to 0.7.0

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -83,10 +83,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: a5e201311cb08bf3912ebbe9a2be096e182d703f881136ec1e81a2338a9e120d
+      sha256: c1b2e9b5ea78c45e1a0788d29606ba27dc5f71f019f32ca5140f61ef071838cf
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.7.1"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  js: ^0.6.3
+  js: ^0.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Summary
Amplitude-Flutter currently uses an old version of `package:js` at 0.6.4. Update dependency using caret syntax to allow for versions `>=0.7.0 <0.8.0` of `package:js`.

Version 0.7.1 was released 9 months ago, and many packages have upgraded to it, causing Amplitude-Flutter to be a blocker to updating packages.
See #191 

Upgrading package:js or switching to js_interop for V4 SDK (beta) will be addressed when browser support is added.