### PR TITLE
chore: add network entitlement for example app

### DIFF
--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - amplitude_flutter (0.0.1):
-    - AmplitudeSwift (~> 1.6)
+    - AmplitudeSwift (~> 1.11.2)
     - Flutter
     - FlutterMacOS
   - AmplitudeSwift (1.11.2):
@@ -24,7 +24,7 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral
 
 SPEC CHECKSUMS:
-  amplitude_flutter: 17471e681e4b91aab4b90f73b62e2b55831c013a
+  amplitude_flutter: 697c784750f50d407c17f7016d794e3c887f3b88
   AmplitudeSwift: ec670fe6f0a0b673bde44b6f02359993cc5513b1
   AnalyticsConnector: 3def11199b4ddcad7202c778bde982ec5da0ebb3
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24

--- a/example/macos/Runner/Release.entitlements
+++ b/example/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Add network entitlement to release entitlement file as well for completeness. Not strictly necessary as we don't anticipate needing to create a release version of the example app, but would be good for developers to see it as reference.

Extra context: for building macOS apps, an entitlement is needed to be able to send network requests. The underlying Amplitude-Swift SDK would be unable to fire any requests without adding entitlements. https://docs.flutter.dev/platform-integration/macos/building#setting-up-entitlements