### PR TITLE
fix: capitalize serverZone before passing to browser SDK

### DIFF
--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -130,6 +130,12 @@ class AmplitudeFlutterPlugin {
       configuration['logLevel'] = LogLevel.values.byName(logLevelString).index.toJS;
     }
 
+    if (call.arguments.containsKey('serverZone')) {
+      var serverZoneString = call.arguments['serverZone'] as String;
+      serverZoneString.toUpperCase();
+      configuration['serverZone'] = serverZoneString.toUpperCase().toJS;
+    }
+
     return configuration;
   }
 }


### PR DESCRIPTION
`serverZone` needs to be capitalized in order to be recognized by the underlying Browser SDK 2