### PR TITLE
fix: removed references to deprecated v1 Android embedding

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -11,7 +11,6 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
-import io.flutter.plugin.common.PluginRegistry.Registrar
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -22,12 +21,6 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler {
 
         var ctxt: Context? = null
 
-        @JvmStatic
-        fun registerWith(registrar: Registrar) {
-            ctxt = registrar.context()
-            val channel = MethodChannel(registrar.messenger(), methodChannelName)
-            channel.setMethodCallHandler(AmplitudeFlutterPlugin())
-        }
     }
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,11 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.amplitude_flutter_example">
 
-    <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-         calls FlutterMain.startInitialization(this); in its onCreate method.
-         In most cases you can leave this as-is, but you if you want to provide
-         additional functionality it is fine to subclass or reimplement
-         FlutterApplication and put your custom class here. -->
     <application
         android:name="${applicationName}"
         android:label="amplitude_flutter_example"


### PR DESCRIPTION
Flutter v1 Android embedding has been deprecated for over 6 years, and newer versions of Flutter will fail to compile if plugins contain it (issue mentions version 3.26+ will fail to compile). This PR removes any remaining v1 Android embedding. Tested that the example app still compiles and runs.

Context:
Jira ticket: https://amplitude.atlassian.net/browse/AMP-106909
Addresses #200 
Should fix #214 