### PR TITLE
chore: add compatibility matrix for Amplitude-Flutter, dart, gradle, android gradle plugin, kotlin gradle plugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ From Amplitude Flutter v3.11.0, we bump up the kotlin version to v1.7.10 to supp
 
 From Amplitude Flutter 3.16.5, we switched from `package:js ^v0.6.3` to using `dart:js_interop` for Flutter web, which requires dart 3.1+.
 
-|Amplitude Flutter|Dart    |Gradle   |Android Gradle Plugin|Kotlin Gradle Plugin|
-|-----------------|--------|---------|---------------------|--------------------|
-| `3.11.+`        | `2.12` | `6.7.1` | `3.6.4`             | `1.7.10`           |
-| `3.16.5`        | `3.1+` | `6.7.1` | `3.6.4`             | `1.7.10`           |
+|Amplitude Flutter  |Dart    |Gradle   |Android Gradle Plugin|Kotlin Gradle Plugin|
+|-------------------|--------|---------|---------------------|--------------------|
+| >= 3.16.5         | >= 3.1 |   6.7.1 | 3.6.4               | 1.7.10             |
+| >= 3.11 <= 3.16.4 | >=2.12 |   6.7.1 | 3.6.4               | 1.7.10             |
 
 
 Learn more about the Android [Gradle Plugin compatibility](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle), [Gradle compatibility](https://docs.gradle.org/current/userguide/compatibility.html#kotlin), and [Kotlin compatibility](https://kotlinlang.org/docs/whatsnew17.html#bumping-minimum-supported-versions).

--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ This is the official Amplitude Flutter SDK developed and maintained by Amplitude
 
 From Amplitude Flutter v3.11.0, we bump up the kotlin version to v1.7.10 to support latest Gradle. For Gradle Version lower than v6.7.1, we recommend to use the Amplitude Flutter v3.10.0. The following matrix lists the minimum support for Amplitude Flutter SDK version.
 
-|Amplitude Flutter|Gradle|Android Gradle Plugin|Kotlin Gradle Plugin|
-|-|-|-|-|
-| `3.11.+` | `6.7.1` | `3.6.4` | `1.7.10` |
+From Amplitude Flutter 3.16.5, we switched from `package:js ^v0.6.3` to using `dart:js_interop` for Flutter web, which requires dart 3.1+.
+
+|Amplitude Flutter|Dart    |Gradle   |Android Gradle Plugin|Kotlin Gradle Plugin|
+|-----------------|--------|---------|---------------------|--------------------|
+| `3.11.+`        | `2.12` | `6.7.1` | `3.6.4`             | `1.7.10`           |
+| `3.16.5`        | `3.1+` | `6.7.1` | `3.6.4`             | `1.7.10`           |
 
 
 Learn more about the Android [Gradle Plugin compatibility](https://developer.android.com/studio/releases/gradle-plugin#updating-gradle), [Gradle compatibility](https://docs.gradle.org/current/userguide/compatibility.html#kotlin), and [Kotlin compatibility](https://kotlinlang.org/docs/whatsnew17.html#bumping-minimum-supported-versions).


### PR DESCRIPTION
Document changes in compatibility matrix for users to quickly see when viewing our github repo.

Jira: https://amplitude.atlassian.net/browse/AMP-120200