### PR TITLE
fix: don't set namespace via package attribute in AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.amplitude.amplitude_flutter">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.INTERNET"/>
 </manifest>


### PR DESCRIPTION
Setting namespace via a source AndroidManifest.xml's package attribute is deprecated, and preferred way past Gradle 7.3 is to set it via build.gradle. We already have it set in build.gradle, so simply remove it from the AndroidManifest.

Addresses #222 
