### PR TITLE
chore: Use minor version in podfile syntax for Amplitude Swift SDK

### DIFF
--- a/darwin/amplitude_flutter.podspec
+++ b/darwin/amplitude_flutter.podspec
@@ -29,5 +29,5 @@ A new Flutter plugin project.
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.9'
-  s.dependency 'AmplitudeSwift', '~> 1.11.2'
+  s.dependency 'AmplitudeSwift', '~> 1.11'
 end


### PR DESCRIPTION
Currently the podspec uses patch version with optimistic operator (`~> 1.11.2`) to specify pod version for the Amplitude-Swift SDK, which translates to versions 1.11.2 <= version < 1.12. We would like to instead include up to but excluding the next major version.


Jira: AMP-98098