### PR TITLE
chore: update minimum version for Amplitude Kotlin SDK

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.10"
 
-    implementation 'com.amplitude:analytics-android:[1.0,2.0)'
+    implementation 'com.amplitude:analytics-android:[1.19,2.0)'
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation "io.mockk:mockk:1.12.4"
     testImplementation "io.mockk:mockk-agent-jvm:1.11.0"


### PR DESCRIPTION
The minimum version for the Amplitude Kotlin SDK is currently set to 1.0, which was released well before the Flutter 4.x SDK. It is also missing features such as autocapture. Update the leftbound version to current minimum of 1.19.

Jira: AMP-98099