### PR TITLE
feat: add getUserId and getDeviceId functions on web/android/ios

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -102,7 +102,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "setUserId" -> {
                 val userId = call.argument<String?>("setUserId")
                 amplitude.setUserId(userId)
-                amplitude.logger.debug("Set user Id to ${call.arguments}")
+                amplitude.logger.debug("Set userId to ${call.arguments}")
 
                 result.success("setUserId called..")
             }
@@ -117,7 +117,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "setDeviceId" -> {
                 val deviceId = call.argument<String>("setDeviceId")
                 deviceId?.let { amplitude.setDeviceId(it) }
-                amplitude.logger.debug("Set device Id to ${call.arguments}")
+                amplitude.logger.debug("Set deviceId to ${call.arguments}")
 
                 result.success("setDeviceId called..")
             }

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -92,12 +92,26 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 result.success("${call.method} called..")
             }
 
+            "getUserId" -> {
+                val userId = amplitude.getUserId()
+                amplitude.logger.debug("Get userId: $userId")
+
+                result.success(userId)
+            }
+
             "setUserId" -> {
                 val userId = call.argument<String?>("setUserId")
                 amplitude.setUserId(userId)
                 amplitude.logger.debug("Set user Id to ${call.arguments}")
 
                 result.success("setUserId called..")
+            }
+
+            "getDeviceId" -> {
+                val deviceId = amplitude.getDeviceId()
+                amplitude.logger.debug("Get deviceId: $deviceId")
+
+                result.success(deviceId)
             }
 
             "setDeviceId" -> {

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -67,6 +67,12 @@ import AmplitudeSwift
                 amplitude?.logger?.warn(message: "\(call.method) called but failed.")
             }
 
+        case "getUserId":
+            let userId = amplitude?.getUserId()
+            amplitude?.logger?.debug(message: "Get user Id: \(String(describing: userId))")
+
+            result(userId)
+
         case "setUserId":
             guard let args = call.arguments as? [String: Any] else {
                 print("\(call.method) called but call.arguments type casting failed.")
@@ -81,6 +87,12 @@ import AmplitudeSwift
             amplitude?.logger?.debug(message: "Set user Id to \(String(describing: userId))")
 
             result("serUserId called..")
+
+        case "getDeviceId":
+            let deviceId = amplitude?.getDeviceId()
+            amplitude?.logger?.debug(message: "Get device Id: \(String(describing: deviceId))")
+
+            result(deviceId)
 
         case "setDeviceId":
             guard let args = call.arguments as? [String: Any] else {

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -69,7 +69,7 @@ import AmplitudeSwift
 
         case "getUserId":
             let userId = amplitude?.getUserId()
-            amplitude?.logger?.debug(message: "Get user Id: \(String(describing: userId))")
+            amplitude?.logger?.debug(message: "Get userId: \(String(describing: userId))")
 
             result(userId)
 
@@ -84,13 +84,13 @@ import AmplitudeSwift
                 return
             }
             amplitude?.setUserId(userId: userId)
-            amplitude?.logger?.debug(message: "Set user Id to \(String(describing: userId))")
+            amplitude?.logger?.debug(message: "Set userId to \(String(describing: userId))")
 
             result("serUserId called..")
 
         case "getDeviceId":
             let deviceId = amplitude?.getDeviceId()
-            amplitude?.logger?.debug(message: "Get device Id: \(String(describing: deviceId))")
+            amplitude?.logger?.debug(message: "Get deviceId: \(String(describing: deviceId))")
 
             result(deviceId)
 
@@ -104,7 +104,7 @@ import AmplitudeSwift
                 return
             }
             amplitude?.setDeviceId(deviceId: deviceId)
-            amplitude?.logger?.debug(message: "Set device Id to \(String(describing: deviceId))")
+            amplitude?.logger?.debug(message: "Set deviceId to \(String(describing: deviceId))")
 
             result("setDeviceId called..")
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - amplitude_flutter (0.0.1):
-    - AmplitudeSwift (~> 1.11.2)
+    - AmplitudeSwift (~> 1.11)
     - Flutter
     - FlutterMacOS
   - AmplitudeSwift (1.11.2):
@@ -24,7 +24,7 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  amplitude_flutter: 697c784750f50d407c17f7016d794e3c887f3b88
+  amplitude_flutter: fd9bf76a1885fe760055877777da18ca4d087088
   AmplitudeSwift: ec670fe6f0a0b673bde44b6f02359993cc5513b1
   AnalyticsConnector: 3def11199b4ddcad7202c778bde982ec5da0ebb3
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7

--- a/example/lib/device_id_form.dart
+++ b/example/lib/device_id_form.dart
@@ -8,6 +8,8 @@ class DeviceIdForm extends StatefulWidget {
 }
 
 class _DeviceIdFormState extends State<DeviceIdForm> {
+  String? _deviceId;
+
   void Function(String) makeHandler(BuildContext context) {
     return (String deviceId) {
       AppState
@@ -22,12 +24,28 @@ class _DeviceIdFormState extends State<DeviceIdForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('Device Id', style: Theme.of(context).textTheme.headlineSmall),
+        Text('Device Id (calls setDeviceId onChange)', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         TextField(
           autocorrect: false,
           decoration: InputDecoration(labelText: 'Device Id'),
           onChanged: makeHandler(context),
+        ),
+        ElevatedButton(
+          onPressed: () async {
+            final newDeviceId = await AppState.of(context).analytics.getDeviceId();
+            setState(() {
+              _deviceId = newDeviceId;
+            });
+          },
+          child: Text('Get Device Id'),
+        ),
+        Row(
+            children: [
+            Text('Fetched Device Id: ', style: Theme.of(context).textTheme.bodyMedium),
+            const SizedBox(height: 10),
+            Text(_deviceId ?? 'No Device Id fetched', style: Theme.of(context).textTheme.bodyMedium),
+          ],
         ),
       ],
     );

--- a/example/lib/user_id_form.dart
+++ b/example/lib/user_id_form.dart
@@ -7,6 +7,8 @@ class UserIdForm extends StatefulWidget {
 }
 
 class _UserIdFormState extends State<UserIdForm> {
+  String? _userId;
+
   void Function(String) makeHandler(BuildContext context) {
     return (String userId) {
       AppState
@@ -21,12 +23,29 @@ class _UserIdFormState extends State<UserIdForm> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        Text('User Id', style: Theme.of(context).textTheme.headlineSmall),
+        Text('User Id (calls setUserId onChange)', style: Theme.of(context).textTheme.headlineSmall),
         const SizedBox(height: 10),
         TextField(
             autocorrect: false,
             decoration: InputDecoration(labelText: 'User Id'),
-            onChanged: makeHandler(context)),
+            onChanged: makeHandler(context)
+          ),
+        ElevatedButton(
+          onPressed: () async {
+            final newUserId = await AppState.of(context).analytics.getUserId();
+            setState(() {
+              _userId = newUserId;
+            });
+          },
+          child: Text('Get User Id'),
+        ),
+        Row(
+            children: [
+            Text('Fetched User Id: ', style: Theme.of(context).textTheme.bodyMedium),
+            const SizedBox(height: 10),
+            Text(_userId ?? 'No User Id fetched', style: Theme.of(context).textTheme.bodyMedium),
+          ],
+        ),
       ],
     );
   }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -12,42 +12,42 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
+      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.1"
+    version: "1.19.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -60,10 +60,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -83,18 +83,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.7"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.8"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -107,10 +107,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
@@ -123,18 +123,18 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.15.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.9.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -144,50 +144,50 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
+      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.1"
+    version: "1.12.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.1.2"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
+      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.1"
+    version: "1.3.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.3"
   vector_math:
     dependency: transitive
     description:
@@ -200,10 +200,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "14.3.0"
 sdks:
-  dart: ">=3.7.0-0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -34,7 +34,7 @@ class Amplitude {
     isBuilt = _init();
   }
 
-  /// Private method to initialize and return a Future<bool>
+  /// Private method to initialize and return a `Future<bool>`
   Future<bool> _init() async {
     try {
       await _channel.invokeMethod('init', configuration.toMap());

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -182,6 +182,14 @@ class Amplitude {
     return await _channel.invokeMethod('revenue', event.toMap());
   }
 
+  /// Get the current user Id.
+  /// ```
+  /// final userId = await amplitude.getUserId();
+  /// ```
+  Future<String?> getUserId() async {
+    return await _channel.invokeMethod('getUserId');
+  }
+
   /// Set a custom user Id.
   ///
   /// If your app has its own login system that you want to track users with,
@@ -195,6 +203,15 @@ class Amplitude {
     properties['setUserId'] = userId;
 
     return await _channel.invokeMethod('setUserId', properties);
+  }
+
+  /// Get the current device ID.
+  ///
+  /// ```
+  /// final deviceId = await amplitude.getDeviceId();
+  /// ```
+  Future<String?> getDeviceId() async {
+    return await _channel.invokeMethod('getDeviceId');
   }
 
   /// Sets a custom device ID.

--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -63,11 +63,7 @@ class AmplitudeFlutterPlugin {
       }
       case "getDeviceId":
       {
-        JSString? deviceId = amplitude.getDeviceId();
-        if (deviceId == null) {
-          return null;
-        }
-        return deviceId.toDart;
+        return amplitude.getDeviceId()?.toDart;
       }
       case "setDeviceId":
       {

--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -48,10 +48,26 @@ class AmplitudeFlutterPlugin {
         JSObject event = getEvent(call);
         amplitude.track(event);
       }
+      case "getUserId":
+      {
+        JSString? userId = amplitude.getUserId();
+        if (userId == null) {
+          return null;
+        }
+        return userId.toDart;
+      }
       case "setUserId":
       {
         String userId = call.arguments['setUserId'];
         amplitude.setUserId(userId.toJS);
+      }
+      case "getDeviceId":
+      {
+        JSString? deviceId = amplitude.getDeviceId();
+        if (deviceId == null) {
+          return null;
+        }
+        return deviceId.toDart;
       }
       case "setDeviceId":
       {

--- a/lib/web/amplitude_js.dart
+++ b/lib/web/amplitude_js.dart
@@ -5,7 +5,9 @@ extension type Amplitude(JSObject _) implements JSObject {
   external JSPromise init(String apiKey, JSObject? configuration);
   external void add(JSObject plugin);
   external void track(JSObject event);
+  external JSString? getUserId();
   external void setUserId(JSString userId);
+  external JSString? getDeviceId();
   external void setDeviceId(JSString devideId);
   external void setOptOut(bool enabled);
   external void reset();

--- a/test/amplitude_test.dart
+++ b/test/amplitude_test.dart
@@ -314,6 +314,15 @@ void main() {
     verify(mockChannel.invokeMethod('revenue', testRevenueMap)).called(1);
   });
 
+  test('Should getUserId calls MethodChannel', () async {
+    when(mockChannel.invokeMethod('getUserId')).thenAnswer((_) async => testUserId);
+
+    final userId = await amplitude.getUserId();
+
+    expect(userId, testUserId);
+    verify(mockChannel.invokeMethod('getUserId')).called(1);
+  });
+
   test('Should setUserId calls MethodChannel', () async {
     when(mockChannel.invokeMethod('setUserId', any))
         .thenAnswer((_) async => null);
@@ -324,14 +333,13 @@ void main() {
         .called(1);
   });
 
-  test('Should setDeviceId calls MethodChannel', () async {
-    when(mockChannel.invokeMethod('setDeviceId', any))
-        .thenAnswer((_) async => null);
+  test('Should getDeviceId calls MethodChannel', () async {
+    when(mockChannel.invokeMethod('getDeviceId')).thenAnswer((_) async => testDeviceId);
 
-    amplitude.setDeviceId(testDeviceId);
+    final deviceId = await amplitude.getDeviceId();
 
-    verify(mockChannel
-        .invokeMethod('setDeviceId', {'setDeviceId': testDeviceId})).called(1);
+    expect(deviceId, testDeviceId);
+    verify(mockChannel.invokeMethod('getDeviceId')).called(1);
   });
 
   test('Should setDeviceId calls MethodChannel', () async {


### PR DESCRIPTION
Flutter SDK 3.x had methods for `getUserId` and `getDeviceId`, while Flutter SDK 4 does not. Customers on the 3.x SDK using `getDeviceId`/`getUserId` are blocked from upgrading to 4.x as a result. All platforms already have `getUserId` and `getDeviceId` so simply add appropriate calls.

Primary changes:
- Add `getUserId` and `getDeviceId` calls to `amplitude.dart`
- Add corresponding calls in Android, iOS, and Web plugin files to call underlying SDK

Jira: https://amplitude.atlassian.net/browse/AMP-125025