### PR TITLE
fix: update minimum version of Amplitude-Kotlin to 1.20

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.10"
 
-    implementation 'com.amplitude:analytics-android:[1.19,2.0)'
+    implementation 'com.amplitude:analytics-android:[1.20,2.0)'
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation "io.mockk:mockk:1.12.4"
     testImplementation "io.mockk:mockk-agent-jvm:1.11.0"


### PR DESCRIPTION
It appears there was an issue on Amplitude-Kotlin introduced in 1.19.3 or 1.19.4, and may have been fixed in 1.20+. Bump minimum version to 1.20 to test if that addresses the issue.

Jira: https://amplitude.atlassian.net/browse/AMP-124672