### PR TITLE
refactor: Hides configuration from public interface and make isBuilt final

### DIFF
--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -10,7 +10,6 @@ import 'events/base_event.dart';
 import 'events/group_identify_event.dart';
 
 class Amplitude {
-  Configuration configuration;
   MethodChannel _channel = const MethodChannel('amplitude_flutter');
 
   /// Whether the Amplitude instance has been successfully initialized
@@ -20,7 +19,7 @@ class Amplitude {
   /// // If care about init complete
   /// await amplitude.isBuilt;
   /// ```
-  late Future<bool> isBuilt;
+  late final Future<bool> isBuilt;
 
   /// Returns an Amplitude instance
   ///
@@ -29,13 +28,13 @@ class Amplitude {
   /// // If care about init complete
   /// await amplitude.isBuilt;
   /// ```
-  Amplitude(this.configuration, [MethodChannel? methodChannel]) {
+  Amplitude(Configuration configuration, [MethodChannel? methodChannel]) {
     _channel = methodChannel ?? _channel;
-    isBuilt = _init();
+    isBuilt = _init(configuration);
   }
 
   /// Private method to initialize and return a `Future<bool>`
-  Future<bool> _init() async {
+  Future<bool> _init(Configuration configuration) async {
     try {
       await _channel.invokeMethod('init', configuration.toMap());
       return true; // Initialization successful


### PR DESCRIPTION
**TL;DR** This PR achieves what is described in this link: https://amplitude.com/docs/sdks/analytics/flutter/flutter-sdk-4-0-migration-guide#configuration

> Configuration is immutable after you pass it to Amplitude.

### Description
The purpose of these changes is because having both configuration and isBuilt publicly mutable is misleading, since changing those attributes will have no impact.

For example, currently it is possible to initialize Amplitude 
```
final amplitude = Amplitude(Configuration(apiKey: "xxx"));
```

And then write
```
amplitude.configuration.flushQueueSize = 1;
```
Thinking this would lead to a on-the-fly reconfiguration of amplitude, which is not true.

Similarly but less important, I made isBuilt final since previosuly it would be possible to modify it, which makes no sense.