### PR TITLE
feat: add getSessionId for all platforms

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -122,6 +122,13 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 result.success("setDeviceId called..")
             }
 
+            "getSessionId" -> {
+                val sessionId = amplitude.sessionId
+                amplitude.logger.debug("Get sessionId: $sessionId")
+
+                result.success(sessionId)
+            }
+
             "reset" -> {
                 amplitude.reset()
                 amplitude.logger.debug("Reset userId and deviceId.")

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -118,6 +118,12 @@ import AmplitudeSwift
 
             result("setDeviceId called..")
 
+        case "getSessionId":
+            let sessionId = amplitude?.getSessionId()
+            amplitude?.logger?.debug(message: "Get sessionId: \(String(describing: sessionId))")
+
+            result(sessionId)
+
         case "reset":
             amplitude?.reset()
             amplitude?.logger?.debug(message: "Reset userId and deviceId.")

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -15,6 +15,7 @@ import 'group_identify_form.dart';
 import 'identify_form.dart';
 import 'reset.dart';
 import 'revenue_form.dart';
+import 'session_id.dart';
 import 'user_id_form.dart';
 
 class MyApp extends StatefulWidget {
@@ -43,6 +44,7 @@ class _MyAppState extends State<MyApp> {
     analytics = Amplitude(Configuration(
         apiKey: widget.apiKey,
         logLevel: LogLevel.debug,
+        flushIntervalMillis: 100,
         defaultTracking: DefaultTrackingOptions.all()));
     initAnalytics();
   }
@@ -83,6 +85,8 @@ class _MyAppState extends State<MyApp> {
                 UserIdForm(),
                 divider,
                 ResetForm(),
+                divider,
+                SessionIdForm(),
                 divider,
                 EventForm(),
                 divider,

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -44,7 +44,6 @@ class _MyAppState extends State<MyApp> {
     analytics = Amplitude(Configuration(
         apiKey: widget.apiKey,
         logLevel: LogLevel.debug,
-        flushIntervalMillis: 100,
         defaultTracking: DefaultTrackingOptions.all()));
     initAnalytics();
   }

--- a/example/lib/session_id.dart
+++ b/example/lib/session_id.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'app_state.dart';
+
+class SessionIdForm extends StatefulWidget {
+  @override
+  State<SessionIdForm> createState() => _SessionIdFormState();
+}
+
+class _SessionIdFormState extends State<SessionIdForm> {
+  int? _sessionId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text('Session Id', style: Theme.of(context).textTheme.headlineSmall),
+        const SizedBox(height: 10),
+        ElevatedButton(
+          onPressed: () async {
+            final newSessionId =
+                await AppState.of(context).analytics.getSessionId();
+            setState(() {
+              _sessionId = newSessionId;
+            });
+          },
+          child: Text('Get Session Id'),
+        ),
+        Row(
+          children: [
+            Text('Fetched Session Id: ',
+                style: Theme.of(context).textTheme.bodyMedium),
+            const SizedBox(height: 10),
+            Text(_sessionId.toString() ?? 'No Session Id fetched',
+                style: Theme.of(context).textTheme.bodyMedium),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/session_id.dart
+++ b/example/lib/session_id.dart
@@ -31,7 +31,7 @@ class _SessionIdFormState extends State<SessionIdForm> {
             Text('Fetched Session Id: ',
                 style: Theme.of(context).textTheme.bodyMedium),
             const SizedBox(height: 10),
-            Text(_sessionId.toString() ?? 'No Session Id fetched',
+            Text(_sessionId.toString(),
                 style: Theme.of(context).textTheme.bodyMedium),
           ],
         ),

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -228,6 +228,15 @@ class Amplitude {
     return await _channel.invokeMethod('setDeviceId', properties);
   }
 
+  /// Get the current session ID.
+  ///
+  /// ```
+  /// final sessionId = await amplitude.getSessionId();
+  /// ```
+  Future<int?> getSessionId() async {
+    return await _channel.invokeMethod('getSessionId');
+  }
+
   /// Web only.
   /// Disables tracking.
   ///

--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -58,8 +58,8 @@ class AmplitudeFlutterPlugin {
         }
       case "setUserId":
         {
-          String userId = call.arguments['setUserId'];
-          amplitude.setUserId(userId.toJS);
+          String? userId = call.arguments['setUserId'];
+          amplitude.setUserId(userId?.toJS);
         }
       case "getDeviceId":
         {
@@ -67,8 +67,12 @@ class AmplitudeFlutterPlugin {
         }
       case "setDeviceId":
         {
-          String deviceId = call.arguments['setDeviceId'];
-          amplitude.setDeviceId(deviceId.toJS);
+          String? deviceId = call.arguments['setDeviceId'];
+          amplitude.setDeviceId(deviceId?.toJS);
+        }
+      case "getSessionId":
+        {
+          return amplitude.getSessionId()?.toDartInt;
         }
       case "reset":
         {

--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -58,8 +58,8 @@ class AmplitudeFlutterPlugin {
         }
       case "setUserId":
         {
-          String? userId = call.arguments['setUserId'];
-          amplitude.setUserId(userId?.toJS);
+          String userId = call.arguments['setUserId'];
+          amplitude.setUserId(userId.toJS);
         }
       case "getDeviceId":
         {
@@ -67,8 +67,8 @@ class AmplitudeFlutterPlugin {
         }
       case "setDeviceId":
         {
-          String? deviceId = call.arguments['setDeviceId'];
-          amplitude.setDeviceId(deviceId?.toJS);
+          String deviceId = call.arguments['setDeviceId'];
+          amplitude.setDeviceId(deviceId.toJS);
         }
       case "getSessionId":
         {

--- a/lib/web/amplitude_js.dart
+++ b/lib/web/amplitude_js.dart
@@ -6,9 +6,10 @@ extension type Amplitude(JSObject _) implements JSObject {
   external void add(JSObject plugin);
   external void track(JSObject event);
   external JSString? getUserId();
-  external void setUserId(JSString userId);
+  external void setUserId(JSString? userId);
   external JSString? getDeviceId();
-  external void setDeviceId(JSString devideId);
+  external void setDeviceId(JSString? devideId);
+  external JSNumber? getSessionId();
   external void setOptOut(bool enabled);
   external void reset();
   external void flush();

--- a/lib/web/amplitude_js.dart
+++ b/lib/web/amplitude_js.dart
@@ -6,9 +6,9 @@ extension type Amplitude(JSObject _) implements JSObject {
   external void add(JSObject plugin);
   external void track(JSObject event);
   external JSString? getUserId();
-  external void setUserId(JSString? userId);
+  external void setUserId(JSString userId);
   external JSString? getDeviceId();
-  external void setDeviceId(JSString? devideId);
+  external void setDeviceId(JSString devideId);
   external JSNumber? getSessionId();
   external void setOptOut(bool enabled);
   external void reset();


### PR DESCRIPTION
`getSessionId` was not supported on Flutter SDK 4, while it was supported in 3.x. This PR adds that capability.

Jira: AMP-126150