### PR TITLE
fix: allow userId and deviceId to be set nullable

### DIFF
--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -58,8 +58,8 @@ class AmplitudeFlutterPlugin {
         }
       case "setUserId":
         {
-          String userId = call.arguments['setUserId'];
-          amplitude.setUserId(userId.toJS);
+          String? userId = call.arguments['setUserId'];
+          amplitude.setUserId(userId?.toJS);
         }
       case "getDeviceId":
         {
@@ -67,8 +67,8 @@ class AmplitudeFlutterPlugin {
         }
       case "setDeviceId":
         {
-          String deviceId = call.arguments['setDeviceId'];
-          amplitude.setDeviceId(deviceId.toJS);
+          String? deviceId = call.arguments['setDeviceId'];
+          amplitude.setDeviceId(deviceId?.toJS);
         }
       case "getSessionId":
         {

--- a/lib/web/amplitude_js.dart
+++ b/lib/web/amplitude_js.dart
@@ -6,9 +6,9 @@ extension type Amplitude(JSObject _) implements JSObject {
   external void add(JSObject plugin);
   external void track(JSObject event);
   external JSString? getUserId();
-  external void setUserId(JSString userId);
+  external void setUserId(JSString? userId);
   external JSString? getDeviceId();
-  external void setDeviceId(JSString devideId);
+  external void setDeviceId(JSString? devideId);
   external JSNumber? getSessionId();
   external void setOptOut(bool enabled);
   external void reset();


### PR DESCRIPTION
userId and deviceId could not be set to null on web. Make nullable as these are valid inputs.