### PR TITLE
fix: Generalize cast for setUserId and setDeviceId for web

### DIFF
--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -74,7 +74,7 @@ class AmplitudeFlutterPlugin {
         }
       case "setUserId":
         {
-          Map<String, dynamic> args = call.arguments['properties'];
+          Map args = call.arguments['properties'];
           String? userId = args['setUserId'];
           instance.setUserId(userId?.toJS);
         }
@@ -84,7 +84,7 @@ class AmplitudeFlutterPlugin {
         }
       case "setDeviceId":
         {
-          Map<String, dynamic> args = call.arguments['properties'];
+          Map args = call.arguments['properties'];
           String? deviceId = args['setDeviceId'];
           instance.setDeviceId(deviceId?.toJS);
         }


### PR DESCRIPTION
The web SDK threw errors when users tried to set userId or deviceId as an overly specific/incorrect cast was being used when grabbing arguments in amplitude_web. Rather than using `Map<String, dynamic>` simply use `Map`.

Fixes #248 
Jira: https://amplitude.atlassian.net/browse/AMP-128689?atlOrigin=eyJpIjoiNjk1NzBlM2ViOTQ2NDgwYjgyZjQwYTRiMDVhMzVhNzgiLCJwIjoiaiJ9