### PR TITLE
fix: (web) make setOptOut grab arguments and pass to TS SDK

### DIFF
--- a/lib/amplitude_web.dart
+++ b/lib/amplitude_web.dart
@@ -102,9 +102,9 @@ class AmplitudeFlutterPlugin {
         }
       case "setOptOut":
         {
-          Map<String, dynamic> args = call.arguments['properties'];
+          Map args = call.arguments['properties'];
           bool enabled = args['setOptOut'];
-          instance.setOptOut(enabled);
+          instance.setOptOut(enabled.toJS);
         }
       default:
         throw PlatformException(

--- a/lib/web/amplitude_js.dart
+++ b/lib/web/amplitude_js.dart
@@ -11,7 +11,7 @@ extension type Amplitude(JSObject _) implements JSObject {
   external JSString? getDeviceId();
   external void setDeviceId(JSString? devideId);
   external JSNumber? getSessionId();
-  external void setOptOut(bool enabled);
+  external void setOptOut(JSBoolean enabled);
   external void reset();
   external void flush();
 }


### PR DESCRIPTION
The `setOptOut` method was crashing on attempting to get `properties` due to improper cast. Fixed cast and converted to JS to fix flow.

Changes:
- Add proper boolean conversion using toJS in setOptOut method
- Ensure consistent boolean handling between Dart and JavaScript layers

Fixes #257 
Jira: https://amplitude.atlassian.net/browse/AMP-131610