### PR TITLE
fix: lock iOS and Android SDK dependencies to specific versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.10"
 
-    implementation 'com.amplitude:analytics-android:[1.20,2.0)'
+    implementation 'com.amplitude:analytics-android:1.21.2'
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation "io.mockk:mockk:1.12.4"
     testImplementation "io.mockk:mockk-agent-jvm:1.11.0"

--- a/darwin/amplitude_flutter.podspec
+++ b/darwin/amplitude_flutter.podspec
@@ -29,5 +29,5 @@ A new Flutter plugin project.
 
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.9'
-  s.dependency 'AmplitudeSwift', '~> 1.11'
+  s.dependency 'AmplitudeSwift', '1.13.7'
 end


### PR DESCRIPTION
### Description
Amplitude-Flutter was not locked to a particular file for iOS and Android SDKs. As a result, users of the SDK could accidentally pull in beta versions.

### Approach taken
Lock Android and iOS versions to specific versions to prevent this in the future.