### PR TITLE
fix: [android] Flutter debug levels now map correctly to Android

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -72,7 +72,11 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             )
 
             call.argument<String>("logLevel")?.let {
-                amplitude.logger.logMode = Logger.LogMode.valueOf(it.uppercase())
+                if (it == "log") {
+                    amplitude.logger.logMode = Logger.LogMode.INFO
+                } else {
+                    amplitude.logger.logMode = Logger.LogMode.valueOf(it.uppercase())
+                }
             }
             amplitude.logger.debug("Amplitude has been successfully initialized.")
 

--- a/lib/configuration.dart
+++ b/lib/configuration.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-import 'package:flutter/foundation.dart';
 import 'autocapture/autocapture.dart';
 import 'constants.dart';
 import 'tracking_options.dart';
@@ -228,23 +226,6 @@ class Configuration {
         instanceName.isEmpty ? Constants.defaultInstanceName : instanceName;
   }
 
-  /// Converts LogLevel enum to platform-specific string value
-  ///
-  /// Android expects "INFO" instead of "LOG", while other platforms expect the enum name
-  /// Web uses enum indices, so special handling is done in amplitude_web.dart
-  /// Maps Flutter LogLevel enum to platform-specific log level strings.
-  ///
-  /// iOS: Uses log level names directly (off, error, warn, log, debug)
-  /// Android: Similar to iOS, but LogLevel.log maps to 'info' instead of 'log'
-  ///          to align with Android native SDK naming conventions
-  /// Web: Uses index-based log levels internally, so string values don't affect behavior
-  String _getPlatformLogLevel(LogLevel logLevel) {
-    if (!kIsWeb && Platform.isAndroid && logLevel == LogLevel.log) {
-      return 'info';
-    }
-    return logLevel.name;
-  }
-
   Map<String, dynamic> toMap() {
     return {
       'apiKey': apiKey,
@@ -252,7 +233,7 @@ class Configuration {
       'flushIntervalMillis': flushIntervalMillis,
       'instanceName': instanceName,
       'optOut': optOut,
-      'logLevel': _getPlatformLogLevel(logLevel),
+      'logLevel': logLevel.name,
       'minIdLength': minIdLength,
       'partnerId': partnerId,
       'flushMaxRetries': flushMaxRetries,

--- a/lib/configuration.dart
+++ b/lib/configuration.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
 import 'autocapture/autocapture.dart';
 import 'constants.dart';
 import 'tracking_options.dart';
@@ -226,6 +228,23 @@ class Configuration {
         instanceName.isEmpty ? Constants.defaultInstanceName : instanceName;
   }
 
+  /// Converts LogLevel enum to platform-specific string value
+  ///
+  /// Android expects "INFO" instead of "LOG", while other platforms expect the enum name
+  /// Web uses enum indices, so special handling is done in amplitude_web.dart
+  /// Maps Flutter LogLevel enum to platform-specific log level strings.
+  ///
+  /// iOS: Uses log level names directly (off, error, warn, log, debug)
+  /// Android: Similar to iOS, but LogLevel.log maps to 'info' instead of 'log'
+  ///          to align with Android native SDK naming conventions
+  /// Web: Uses index-based log levels internally, so string values don't affect behavior
+  String _getPlatformLogLevel(LogLevel logLevel) {
+    if (!kIsWeb && Platform.isAndroid && logLevel == LogLevel.log) {
+      return 'info';
+    }
+    return logLevel.name;
+  }
+
   Map<String, dynamic> toMap() {
     return {
       'apiKey': apiKey,
@@ -233,7 +252,7 @@ class Configuration {
       'flushIntervalMillis': flushIntervalMillis,
       'instanceName': instanceName,
       'optOut': optOut,
-      'logLevel': logLevel.name,
+      'logLevel': _getPlatformLogLevel(logLevel),
       'minIdLength': minIdLength,
       'partnerId': partnerId,
       'flushMaxRetries': flushMaxRetries,

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -17,6 +17,17 @@ class Constants {
       30 * 60 * 1000; // 30 minutes
 }
 
+/// Log level enum that maps to platform-specific log levels.
+///
+/// iOS: Uses log level names directly (off, error, warn, log, debug)
+/// Android: Uses log level names directly, but LogLevel.log maps to 'info' instead of 'log' in AmplitudeFlutterPlugin.kt
+/// Web: Uses index-based log levels internally, so string values don't affect behavior
+///      The mapping is:
+///      LogLevel.off -> LogLevel.None
+///      LogLevel.error -> LogLevel.Error
+///      LogLevel.warn -> LogLevel.Warn
+///      LogLevel.log -> LogLevel.Verbose
+///      LogLevel.debug -> LogLevel.Debug
 enum LogLevel {
   off,
   error,

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -17,13 +17,6 @@ class Constants {
       30 * 60 * 1000; // 30 minutes
 }
 
-
-/// Log level enum that maps to platform-specific log levels.
-///
-/// iOS: Uses log level names directly (off, error, warn, log, debug)
-/// Android: Similar to iOS, but LogLevel.log maps to 'info' instead of 'log'
-///          to align with Android native SDK naming conventions
-/// Web: Uses index-based log levels internally, so string values don't affect behavior
 enum LogLevel {
   off,
   error,

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -17,6 +17,13 @@ class Constants {
       30 * 60 * 1000; // 30 minutes
 }
 
+
+/// Log level enum that maps to platform-specific log levels.
+///
+/// iOS: Uses log level names directly (off, error, warn, log, debug)
+/// Android: Similar to iOS, but LogLevel.log maps to 'info' instead of 'log'
+///          to align with Android native SDK naming conventions
+/// Web: Uses index-based log levels internally, so string values don't affect behavior
 enum LogLevel {
   off,
   error,


### PR DESCRIPTION
Debug enums are inconsistent across iOS, Android, and Web. Previously, debug enums only mapped perfectly with iOS. Android is mostly the same, other than using log rather than info. Web uses indices, so it was not impacted. 

Tested that Android now runs and is able to compile in release mode.

Thanks to @devgianlu for spotting this https://github.com/amplitude/Amplitude-Flutter/issues/263#issuecomment-3022710741

fixes #263 
Jira: https://amplitude.atlassian.net/browse/AMP-132550