### PR TITLE
fix: [android] Remove duplicate install event tracking

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -168,17 +168,6 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             } else {
                 val utils = DefaultEventUtils(amplitude)
 
-                if (appLifecycles) {
-                    val packageManager = ctxt.packageManager
-                    val packageInfo = try {
-                        packageManager.getPackageInfo(ctxt.packageName, 0)
-                    } catch (ex: PackageManager.NameNotFoundException) {
-                        println("Error occurred in getting package info. " + ex.message)
-                        null
-                    }
-                    packageInfo?.let { utils.trackAppUpdatedInstalledEvent(it) }
-                }
-
                 if (deepLinks) {
                     activity.get()?.let { utils.trackDeepLinkOpenedEvent(it) }
                 }

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -46,10 +46,6 @@ import AmplitudeSwift
 
             amplitude?.logger?.debug(message: "Amplitude has been successfully initialized.")
 
-            // Track DET app lifecycle: application installed and updated events
-            let utils = DefaultEventUtils(amplitude: amplitude!)
-            utils.trackAppUpdatedInstalledEvent()
-
             result("init called..")
             return
         }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,23 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+                        <!-- Intent filter for custom scheme deeplinks -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="myapp"/>
+            </intent-filter>
+
+            <!-- Intent filter for HTTP/HTTPS deeplinks -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE"/>
+                <data android:scheme="https"
+                      android:host="myapp.com"/>
+            </intent-filter>
+
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->


### PR DESCRIPTION
Remove manual trackAppUpdatedInstalledEvent call in Flutter plugin since Android SDK automatically handles app lifecycle events when appLifecycles is enabled in DefaultTrackingOptions. This prevents duplicate install events that only occurred in Flutter apps. 

Additionally, added deeplink handling for the Android example app.

Tested manually that installing app no longer double tracks install 

Jira: https://amplitude.atlassian.net/browse/AMP-133754