### PR TITLE
fix: adding ability to track revenue currency

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -319,6 +319,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         (args["quantity"] as? Int)?.let { event.quantity = it }
         (args["product_id"] as? String)?.let { event.productId = it }
         (args["revenue_type"] as? String)?.let { event.revenueType = it }
+        (args["currency"] as? String)?.let { event.currency = it }
         (args["extra"] as? Map<String, Any>)?.let {
             event.extra = it
         }

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -419,6 +419,9 @@ import AmplitudeSwift
         if let revenueType = args["revenue_type"] as? String {
             event.revenueType = revenueType
         }
+        if let currency = args["currency"] as? String {
+            event.currency = currency
+        }
         if let extra = args["extra"] as? [String: Any] {
             event.extra = extra
         }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  amplitude_flutter: 4eb26cea5f147c917075bc8cb57449de518159a5
+  amplitude_flutter: 1d60b513230b24eed6b41a5807f3af510162e875
   AmplitudeCore: ecc568da676d59917dd1d60221eefe640fcd7f87
   AmplitudeSwift: e96d3001ae5d20b596b9755e69840b5c75ea3adc
   AnalyticsConnector: 3def11199b4ddcad7202c778bde982ec5da0ebb3

--- a/example/lib/revenue_form.dart
+++ b/example/lib/revenue_form.dart
@@ -15,6 +15,7 @@ class _RevenueFormState extends State<RevenueForm> {
       TextEditingController(text: 'specialProduct');
   final TextEditingController price = TextEditingController(text: '41.23');
   final TextEditingController quantity = TextEditingController(text: '2');
+  final TextEditingController currency = TextEditingController(text: 'USD');
 
   void onPress() {
     if (productId.text.isNotEmpty &&
@@ -23,7 +24,9 @@ class _RevenueFormState extends State<RevenueForm> {
       final revenue = Revenue()
         ..price = double.tryParse(price.text)!
         ..quantity = int.tryParse(quantity.text)!
-        ..productId = productId.text;
+        ..productId = productId.text
+        ..revenueCurrency = currency.text;
+
       AppState.of(context)
         ..analytics.revenue(revenue)
         ..setMessage('Revenue Sent.');
@@ -56,6 +59,10 @@ class _RevenueFormState extends State<RevenueForm> {
             ],
             decoration: dec.copyWith(labelText: 'Quantity'),
             controller: quantity),
+        vertSpace,
+        TextField(
+            decoration: dec.copyWith(labelText: 'Currency (e.g., USD, EUR)'),
+            controller: currency),
         ElevatedButton(child: const Text('Send Revenue'), onPressed: onPress)
       ],
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -12,10 +12,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -60,10 +60,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -83,10 +83,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -200,10 +200,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
 sdks:
   dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/events/base_event.dart
+++ b/lib/events/base_event.dart
@@ -47,6 +47,7 @@ class BaseEvent extends EventOptions {
     int? quantity,
     String? productId,
     String? revenueType,
+    String? currency,
     Map<String, dynamic>? extra,
     String? partnerId,
     this.eventProperties,
@@ -90,6 +91,7 @@ class BaseEvent extends EventOptions {
           quantity: quantity,
           productId: productId,
           revenueType: revenueType,
+          currency: currency,
           extra: extra,
           partnerId: partnerId,
         );
@@ -138,6 +140,7 @@ class BaseEvent extends EventOptions {
       if (quantity != null) 'quantity': quantity,
       if (productId != null) 'product_id': productId,
       if (revenueType != null) 'revenue_type': revenueType,
+      if (currency != null) 'currency': currency,
       if (extra != null) 'extra': extra,
       if (partnerId != null) 'partner_id': partnerId,
       'attempts': attempts,
@@ -180,6 +183,7 @@ class BaseEvent extends EventOptions {
     quantity = options.quantity ?? quantity;
     productId = options.productId ?? productId;
     revenueType = options.revenueType ?? revenueType;
+    currency = options.currency ?? currency;
     extra = options.extra ?? extra;
     partnerId = options.partnerId ?? partnerId;
     sessionId = options.sessionId ?? sessionId;

--- a/lib/events/event_options.dart
+++ b/lib/events/event_options.dart
@@ -43,6 +43,7 @@ class EventOptions {
   int? quantity;
   String? productId;
   String? revenueType;
+  String? currency;
   Map<String, dynamic>? extra;
   // TODO(xinyi): callback is currently not supported until method channel returns event callback of each platform
   String? partnerId;
@@ -85,6 +86,7 @@ class EventOptions {
     this.quantity,
     this.productId,
     this.revenueType,
+    this.currency,
     this.extra,
     this.partnerId,
   });

--- a/lib/events/revenue.dart
+++ b/lib/events/revenue.dart
@@ -2,6 +2,7 @@ import 'revenue_event.dart';
 
 class RevenueConstants {
   static const String revenueProductId = '\$productId';
+  static const String revenueCurrency = '\$currency';
   static const String revenueQuantity = '\$quantity';
   static const String revenuePrice = '\$price';
   static const String revenueType = '\$revenueType';
@@ -15,6 +16,7 @@ class Revenue {
   double? price;
   double? revenue;
   String? productId;
+  String? revenueCurrency;
   String? revenueType;
   String? receipt;
   String? receiptSig;
@@ -29,6 +31,9 @@ class Revenue {
     eventProperties[RevenueConstants.revenueQuantity] = quantity;
     if (productId != null) {
       eventProperties[RevenueConstants.revenueProductId] = productId;
+    }
+    if (revenueCurrency != null) {
+      eventProperties[RevenueConstants.revenueCurrency] = revenueCurrency;
     }
     if (revenueType != null) {
       eventProperties[RevenueConstants.revenueType] = revenueType;

--- a/test/amplitude_test.dart
+++ b/test/amplitude_test.dart
@@ -346,6 +346,36 @@ void main() {
     })).called(1);
   });
 
+  test('Should revenue calls MethodChannel with currency', () async {
+    when(mockChannel.invokeMethod('revenue', any))
+        .thenAnswer((_) async => null);
+
+    final revenue = Revenue()
+      ..price = testPrice
+      ..quantity = testQuantity
+      ..productId = testProductId
+      ..revenueCurrency = 'USD';
+    await amplitude.revenue(revenue);
+
+    final testRevenueMap = Map.from(testEventMap);
+    testRevenueMap['event_type'] = Constants.revenueEvent;
+    testRevenueMap['currency'] = 'USD'; // BaseEvent currency field
+    testRevenueMap['event_properties'] = {};
+    testRevenueMap['event_properties'][RevenueConstants.revenuePrice] =
+        testPrice;
+    testRevenueMap['event_properties'][RevenueConstants.revenueQuantity] =
+        testQuantity;
+    testRevenueMap['event_properties'][RevenueConstants.revenueProductId] =
+        testProductId;
+    testRevenueMap['event_properties'][RevenueConstants.revenueCurrency] =
+        'USD'; // Event property currency
+
+    verify(mockChannel.invokeMethod('revenue', {
+      'instanceName': Constants.defaultInstanceName,
+      'event': testRevenueMap
+    })).called(1);
+  });
+
   test('Should getUserId calls MethodChannel', () async {
     when(mockChannel.invokeMethod('getUserId', any))
         .thenAnswer((_) async => testUserId);

--- a/test/amplitude_test.dart
+++ b/test/amplitude_test.dart
@@ -359,7 +359,6 @@ void main() {
 
     final testRevenueMap = Map.from(testEventMap);
     testRevenueMap['event_type'] = Constants.revenueEvent;
-    testRevenueMap['currency'] = 'USD'; // BaseEvent currency field
     testRevenueMap['event_properties'] = {};
     testRevenueMap['event_properties'][RevenueConstants.revenuePrice] =
         testPrice;


### PR DESCRIPTION
Exposes a field for currency in the Flutter SDK to get revenue currency.

Manually tested to see that currency gets sent in events. Matched what was sent by native iOS SDK example app. Works with or without a value provided for currency (gets omitted if not present).

<img width="416" height="251" alt="image" src="https://github.com/user-attachments/assets/f1b96a5e-3db7-4e62-95d8-a02987b63e6f" />


Jira: https://amplitude.atlassian.net/browse/AMP-124899