### PR TITLE
fix: [android] "Application Opened" events now track correctly for cold starts

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -173,7 +173,9 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                     // Manually trigger Application Opened since automatic tracking doesn't work reliably in Flutter for cold starts
                     // Warm starts are tracked automatically by the SDK
                     activity.get()?.let { currentActivity ->
-                        trackApplicationOpenedEvent(utils, currentActivity)
+                        val packageManager = currentActivity.packageManager
+                        val packageInfo = packageManager.getPackageInfo(currentActivity.packageName, 0)
+                        utils.trackAppOpenedEvent(packageInfo, true)
                         appOpenedTracked = true
                     }
                 }
@@ -224,22 +226,6 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         call.argument<Boolean>("useAppSetIdForDeviceId")?.let { configuration.useAppSetIdForDeviceId = it }
 
         return configuration
-    }
-
-    private fun trackApplicationOpenedEvent(utils: DefaultEventUtils, activity: Activity) {
-        try {
-            val packageManager = activity.packageManager
-            val packageInfo = packageManager.getPackageInfo(activity.packageName, 0)
-
-            // Use the SDK's trackAppOpenedEvent method
-            val method = utils.javaClass.getMethod("trackAppOpenedEvent",
-                android.content.pm.PackageInfo::class.java,
-                Boolean::class.javaPrimitiveType)
-            method.invoke(utils, packageInfo, true)
-        } catch (e: Exception) {
-            // Fallback: manually track the event
-            instances.values.firstOrNull()?.track("[Amplitude] Application Opened")
-        }
     }
 
     private fun convertMapToTrackingOptions(map: Map<String, Any>): TrackingOptions {


### PR DESCRIPTION
For flutter-android applications, "Application Opened" events were not being tracked for cold starts, but were being tracked for warm starts (when app was closed and freshly opened vs was in memory/background and reopened). This PR fixes this so that "Application Opened" events can automatically be tracked from cold starts as well.

It's likely that the lifecycle detection doesn't occur correctly in a Flutter context, so manually track "Application Opened" the first time the method is run.

Jira: https://amplitude.atlassian.net/browse/AMP-135661