### PR TITLE
fix: bump minimum Android-Kotlin version for revenue changes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.10"
 
-    implementation 'com.amplitude:analytics-android:[1.20,2.0)'
+    implementation 'com.amplitude:analytics-android:[1.22,2.0)'
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation "io.mockk:mockk:1.12.4"
     testImplementation "io.mockk:mockk-agent-jvm:1.11.0"


### PR DESCRIPTION
Revenue changes were introduced in 1.20.2. Current newest version is 1.22, so just bump to latest.