### PR TITLE
fix: manually track ios lifecycle events with dedup logic

### DIFF
--- a/darwin/Classes/LifecycleDeduplicationPlugin.swift
+++ b/darwin/Classes/LifecycleDeduplicationPlugin.swift
@@ -1,0 +1,38 @@
+import Foundation
+import AmplitudeSwift
+
+// Plugin to deduplicate lifecycle events within a time window
+class LifecycleDeduplicationPlugin: BeforePlugin {
+    private var eventTimestamps: [String: Date] = [:]
+    private let deduplicationWindowSeconds: TimeInterval = 1.0
+
+    override func execute(event: BaseEvent) -> BaseEvent? {
+        let eventType = event.eventType
+
+        guard ["[Amplitude] Application Installed", "[Amplitude] Application Updated", "[Amplitude] Application Opened"].contains(eventType) else {
+            return event
+        }
+
+        let now = Date()
+
+        // Check if we've seen this event type recently
+        if let lastTimestamp = eventTimestamps[eventType] {
+            let timeSinceLastEvent = now.timeIntervalSince(lastTimestamp)
+
+            if timeSinceLastEvent < deduplicationWindowSeconds {
+                // Too soon since last event of this type, drop it
+                return nil
+            }
+        }
+
+        // Update timestamp for this event type
+        eventTimestamps[eventType] = now
+
+        // Clean up old timestamps (older than window)
+        eventTimestamps = eventTimestamps.filter { _, timestamp in
+            now.timeIntervalSince(timestamp) < deduplicationWindowSeconds
+        }
+
+        return event
+    }
+}

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -43,8 +43,19 @@ import AmplitudeSwift
                     library: configArgs["library"] as? String ?? "amplitude-flutter/unknown"
                 )
             )
+            // Add deduplication plugin to prevent double lifecycle events
+            let deduplicationPlugin = LifecycleDeduplicationPlugin()
+            amplitude?.add(plugin: deduplicationPlugin)
 
             amplitude?.logger?.debug(message: "Amplitude has been successfully initialized.")
+
+
+
+            // iOS lifecycle event tracking is unreliable in Flutter, so we manually track the events
+            // However, duplicate tracking is possible, so we use a deduplication plugin to prevent it
+            let utils = DefaultEventUtils(amplitude: amplitude!)
+            utils.trackAppUpdatedInstalledEvent()
+            utils.trackAppOpenedEvent()
 
             result("init called..")
             return

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -49,8 +49,6 @@ import AmplitudeSwift
 
             amplitude?.logger?.debug(message: "Amplitude has been successfully initialized.")
 
-
-
             // iOS lifecycle event tracking is unreliable in Flutter, so we manually track the events
             // However, duplicate tracking is possible, so we use a deduplication plugin to prevent it
             let utils = DefaultEventUtils(amplitude: amplitude!)

--- a/darwin/amplitude_flutter.podspec
+++ b/darwin/amplitude_flutter.podspec
@@ -32,5 +32,5 @@ The official Amplitude Flutter SDK for tracking analytics events in your Flutter
     'DEBUG_INFORMATION_FORMAT' => 'dwarf-with-dsym'
   }
   s.swift_version = '5.9'
-  s.dependency 'AmplitudeSwift', '~> 1.14'
+  s.dependency 'AmplitudeSwift', '~> 1.15'
 end


### PR DESCRIPTION
Fix iOS Lifecycle Event Tracking in Flutter

Problem:
The Flutter SDK has unreliable iOS lifecycle event tracking on real devices:

1. Missing "Application Installed" Events: The native iOS SDK's automatic lifecycle tracking fails to fire "Application Installed" events on real devices, though it works correctly in simulators.

2. Missing "Application Opened" Events: Cold start detection fails because IOSVendorSystem.applicationState == .active returns false during Flutter initialization on real devices, causing "Application Opened" events to be skipped.

3. Previous Incomplete Fix: An earlier attempt manually called utils.trackAppUpdatedInstalledEvent() but was removed when testing showed it "worked without it" - however, this testing was only done on simulators where the issue doesn't reproduce.

4. Flutter-Specific Issue: This problem is not evident in native iOS apps using the Amplitude-Swift SDK directly, indicating the issue stems from Flutter's bridge architecture and initialization timing.

Root Cause:
Flutter's initialization timing on real devices interferes with the native iOS SDK's ability to:
- Detect proper application state during launch
- Reliably trigger UIApplication lifecycle notifications
- Access storage systems early in the app lifecycle

Solution:
- Manual Tracking: Explicitly call lifecycle tracking methods (trackAppUpdatedInstalledEvent(), trackAppOpenedEvent()) during Flutter plugin initialization
- Deduplication: Implement LifecycleDeduplicationPlugin with a 1-second time window to prevent double-tracking when both native and manual tracking succeed
- Flutter-Specific Fix: This approach addresses the unique challenges of Flutter's bridge architecture while maintaining compatibility with native iOS behavior

Impact:
Ensures consistent "Application Installed" and "Application Opened" event tracking across all iOS devices, preventing data gaps in user journey analytics.

Depends on https://github.com/amplitude/Amplitude-Swift/pull/321