### PR TITLE
fix(android): deviceId now passed as parameter to native Android SDK

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -224,6 +224,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         call.argument<Boolean>("useAdvertisingIdForDeviceId")
             ?.let { configuration.useAdvertisingIdForDeviceId = it }
         call.argument<Boolean>("useAppSetIdForDeviceId")?.let { configuration.useAppSetIdForDeviceId = it }
+        call.argument<String>("deviceId")?.let { configuration.deviceId = it }
 
         return configuration
     }


### PR DESCRIPTION
### Problem
The underlying Amplitude-Kotlin supports `deviceId` being passed as a parameter as part of the `Configuration` object to set `deviceId` during initialization. The Flutter SDK plugin did not parse the deviceId and pass it through to the Kotlin SDK, so this did not actually occur.

### Solution
Grab `deviceId` in getConfiguration method in AmplitudeFlutterPlugin.kt so that it is correctly passed through to Kotlin SDK. 

### Testing
Manually tested that deviceId is now reflected in initialization


Jira: https://amplitude.atlassian.net/browse/AMP-141303
Fixes #281 