### PR TITLE
fix: lock iOS and Android SDK dependencies to specific versions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.10"
 
-    implementation 'com.amplitude:analytics-android:[1.22,2.0)'
+    // Locked to specific version to prevent binary compatibility issues.
+    // Version range [1.22,2.0) previously caused NoSuchMethodError when Gradle
+    // resolved different versions at compile-time vs runtime (see #283).
+    implementation 'com.amplitude:analytics-android:1.22.4'
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation "io.mockk:mockk:1.12.4"
     testImplementation "io.mockk:mockk-agent-jvm:1.11.0"

--- a/darwin/amplitude_flutter.podspec
+++ b/darwin/amplitude_flutter.podspec
@@ -32,5 +32,5 @@ The official Amplitude Flutter SDK for tracking analytics events in your Flutter
     'DEBUG_INFORMATION_FORMAT' => 'dwarf-with-dsym'
   }
   s.swift_version = '5.9'
-  s.dependency 'AmplitudeSwift', '~> 1.14'
+  s.dependency 'AmplitudeSwift', '1.15.1'
 end


### PR DESCRIPTION
### Problem
Users reported `NoSuchMethodError` crashes when initializing Amplitude (#283). The error occurred due to Gradle resolving different versions of `analytics-android` at compile-time vs runtime.

### Root Cause
The dependency was specified as a version range `[1.22,2.0)`. When Android SDK v1.22.4 added a new constructor parameter to `Configuration`, it created a binary incompatibility. Kotlin's default parameter handling generates specific bytecode signatures that don't match when the constructor signature changes.

Two scenarios can cause the crash:

**1. Dependency Conflict Resolution:**
- Flutter plugin compiles against v1.22.4 (52 parameters)
- Another library forces v1.22.3 at runtime (51 parameters)
- Result: NoSuchMethodError

**2. Gradle Lockfile + Incremental Build:**
- Plugin compiled against v1.22.3 (lockfile)
- Lockfile updated to v1.22.4
- Incremental build doesn't recompile plugin
- Result: Old bytecode + new library = NoSuchMethodError

### Solution
Lock Android SDK to specific version `1.22.4` to ensure compile-time and runtime use the same version.

### Changes
- `android/build.gradle`: `analytics-android:[1.22,2.0)` → `analytics-android:1.22.4`
- Added comment documenting the version lock rationale

### Testing
- ✅ Example app builds and runs without crashes
- ✅ All existing functionality preserved

Closes #283