### PR TITLE
fix: update iOS SDK dependency to allow minor version updates

### DIFF
--- a/darwin/amplitude_flutter.podspec
+++ b/darwin/amplitude_flutter.podspec
@@ -32,5 +32,5 @@ The official Amplitude Flutter SDK for tracking analytics events in your Flutter
     'DEBUG_INFORMATION_FORMAT' => 'dwarf-with-dsym'
   }
   s.swift_version = '5.9'
-  s.dependency 'AmplitudeSwift', '1.15.1'
+  s.dependency 'AmplitudeSwift', '~> 1.16'
 end


### PR DESCRIPTION
The iOS Podspec of amplitude_flutter pinned AmplitudeSwift to an exact version (1.15.1), which caused CocoaPods dependency resolution conflicts and prevented upgrading the SDK.

In addition, it has been verified that AmplitudeSwift 1.15.1 crashes on iOS 15.3, making it unsuitable to remain as a fixed dependency version.

This change relaxes the AmplitudeSwift version constraint to allow newer SDK versions, resolving dependency conflicts and improving stability on iOS 15.3 and later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Relaxes the CocoaPods dependency to avoid resolution conflicts and allow minor SDK upgrades.
> 
> - In `darwin/amplitude_flutter.podspec`, changes `AmplitudeSwift` from exact `1.15.1` to `~> 1.16`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fb416483d7b45466776ed878d6bd33d87a507f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->