### PR TITLE
fix: update Amplitude-Swift to 1.16.5 iOS to fix missing installed/app opened events

### DIFF
--- a/darwin/amplitude_flutter.podspec
+++ b/darwin/amplitude_flutter.podspec
@@ -32,5 +32,5 @@ The official Amplitude Flutter SDK for tracking analytics events in your Flutter
     'DEBUG_INFORMATION_FORMAT' => 'dwarf-with-dsym'
   }
   s.swift_version = '5.9'
-  s.dependency 'AmplitudeSwift', '1.15.1'
+  s.dependency 'AmplitudeSwift', '1.16.5'
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,11 +1,11 @@
 PODS:
   - amplitude_flutter (0.0.1):
-    - AmplitudeSwift (~> 1.14)
+    - AmplitudeSwift (= 1.16.5)
     - Flutter
     - FlutterMacOS
-  - AmplitudeCore (1.2.1)
-  - AmplitudeSwift (1.14.0):
-    - AmplitudeCore (< 2.0.0, >= 1.1.0)
+  - AmplitudeCore (1.3.1)
+  - AmplitudeSwift (1.16.5):
+    - AmplitudeCore (< 2.0.0, >= 1.3.1)
     - AnalyticsConnector (~> 1.3.0)
   - AnalyticsConnector (1.3.1)
   - Flutter (1.0.0)
@@ -27,9 +27,9 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  amplitude_flutter: d6027be1b5dbb2eede211833f3b9233c5ea6af83
-  AmplitudeCore: ba1fce0cfad558ae69c8927439998a0b7d942451
-  AmplitudeSwift: e96d3001ae5d20b596b9755e69840b5c75ea3adc
+  amplitude_flutter: fb1d2c283644b0fcb150ba75e109f5537d4dd562
+  AmplitudeCore: c47c0a661bec076a197bc75a5a7b4c413da288a5
+  AmplitudeSwift: f8cc113e5880a9410c1b4108e4d83aa2c2be0c6e
   AnalyticsConnector: 3def11199b4ddcad7202c778bde982ec5da0ebb3
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,10 +60,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -83,26 +83,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
@@ -184,18 +184,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -205,5 +205,5 @@ packages:
     source: hosted
     version: "14.3.1"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"


### PR DESCRIPTION
This was an issue that needed to be fixed on Amplitude-Swift, so this simply bumps version of Amplitude-Swift

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the native iOS/macOS SDK dependency to address issues fixed upstream and syncs example app locks.
> 
> - Bumps `AmplitudeSwift` to `1.16.5` in `darwin/amplitude_flutter.podspec`
> - Regenerates `example/ios/Podfile.lock` reflecting `AmplitudeSwift 1.16.5` and `AmplitudeCore 1.3.1`
> - Updates `example/pubspec.lock` with minor transitive dependency changes and lowers Dart SDK floor to `>=3.7.0-0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4549b18c33e308863be2cdde7d1c06c6991d1eb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->