### PR TITLE
feat(internal): improvements to support other Amplitude Flutter SDKs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,16 @@ PR titles should follow [conventional commit standards](https://www.conventional
 - `ci(<optional scope>)`: Changes to our CI configuration files and scripts
 - `chore(<optional scope>)`: Other changes that don't modify src or test files
 - `revert(<optional scope>)`: Revert commit
+
+## Internal Amplitude Dev Contribution Notes
+
+### Integrating a different Amplitude Flutter SDK
+In Amplitude Flutter, we don't currently support the Amplitude Plugin architecture that we do on other platforms (e.g. iOS, Android, React Native, etc.). Because of this, we needed way for other Amplitude Flutter SDK's to hook into the underlying `Amplitude` instance from a native context to be able to use Amplitude plugins.
+
+To enable this, the `amplitude_flutter` plugin exposes `getAmplitudeInstanceById` on each native platform, at the Flutter native layer, so that
+other Amplitude Flutter plugins (e.g. [Amplitude Engagement](https://pub.dev/packages/amplitude_engagement_flutter)) can obtain the underlying
+native `Amplitude` instance by its `configuration.instanceName`.
+
+Then on each native platform, once we have obtained the underlying `Amplitude` instance, we can then add the Amplitude plugin to the instance.
+
+For example, on iOS, we can add the Amplitude Engagement plugin to the instance by calling for example: `amplitude.add(engagement.getPlugin())`.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.10"
+    implementation "androidx.annotation:annotation:1.7.0"
 
     // Locked to specific version to prevent binary compatibility issues.
     // Version range [1.22,2.0) previously caused NoSuchMethodError when Gradle

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -21,7 +21,12 @@ import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import java.lang.ref.WeakReference
 
+// Global variable to store the plugin instance for the duration of the app's lifecycle
+// This is used to access the plugin instance from a native context in other Amplitude SDKs.
+private var pluginInstance: AmplitudeFlutterPlugin? = null
+
 class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
+    private val instances: MutableMap<String, Amplitude> = mutableMapOf()
     private var activity: WeakReference<Activity?> = WeakReference(null)
     lateinit var ctxt: Context
     private var appOpenedTracked = false
@@ -30,10 +35,20 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     companion object {
         private const val methodChannelName = "amplitude_flutter"
-        private val instances: MutableMap<String, Amplitude> = mutableMapOf()
 
+        /**
+         * Returns an Amplitude instance by its instance name.
+         * This method is intended to be used by other Amplitude SDKs to be able to
+         * access the underlying Amplitude instance from a native context.
+         *
+         * @param id The instance name of the Amplitude instance.
+         * @return The Amplitude instance or null if not found.
+         */
+        @InternalAmplitudeApi
         @JvmStatic
-        fun findAmplitudeInstanceById(id: String): Amplitude? = instances[id]
+        fun getAmplitudeInstanceById(id: String): Amplitude? {
+            return pluginInstance?.instances?.get(id)
+        }
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
@@ -56,10 +71,12 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         ctxt = binding.applicationContext
         channel = MethodChannel(binding.binaryMessenger, methodChannelName)
         channel.setMethodCallHandler(this)
+        pluginInstance = this
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+        pluginInstance = null
     }
 
     override fun onMethodCall(call: MethodCall, result: Result) {
@@ -344,3 +361,11 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         return event
     }
 }
+
+@RequiresOptIn(
+    message = "This is an internal Amplitude API and is not intended for use outside of Amplitude SDKs.",
+    level = RequiresOptIn.Level.ERROR
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION)
+annotation class InternalAmplitudeApi

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -82,7 +82,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         if (call.method == "init") {
             val configuration = getConfiguration(call)
             val amplitude = Amplitude(configuration)
-            instances[configuration.instanceName] = amplitude
+            instances += mapOf(configuration.instanceName to amplitude)
 
             // Set library
             amplitude.add(

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -22,7 +22,6 @@ import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import java.lang.ref.WeakReference
 
 class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
-    private var instances: Map<String, Amplitude> = mutableMapOf()
     private var activity: WeakReference<Activity?> = WeakReference(null)
     lateinit var ctxt: Context
     private var appOpenedTracked = false
@@ -31,6 +30,10 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     companion object {
         private const val methodChannelName = "amplitude_flutter"
+        private val instances: MutableMap<String, Amplitude> = mutableMapOf()
+
+        @JvmStatic
+        fun findAmplitudeInstanceById(id: String): Amplitude? = instances[id]
     }
 
     override fun onAttachedToActivity(binding: ActivityPluginBinding) {
@@ -63,7 +66,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         if (call.method == "init") {
             val configuration = getConfiguration(call)
             val amplitude = Amplitude(configuration)
-            instances += mapOf(configuration.instanceName to amplitude)
+            instances[configuration.instanceName] = amplitude
 
             // Set library
             amplitude.add(

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -2,6 +2,7 @@ package com.amplitude.amplitude_flutter
 
 import android.app.Activity
 import android.content.Context
+import androidx.annotation.RestrictTo
 import com.amplitude.android.Amplitude
 import com.amplitude.android.Configuration
 import com.amplitude.android.DefaultTrackingOptions
@@ -44,6 +45,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
          * @param id The instance name of the Amplitude instance.
          * @return The Amplitude instance or null if not found.
          */
+        @RestrictTo(RestrictTo.Scope.LIBRARY_GROUP_PREFIX)
         @JvmStatic
         fun getAmplitudeInstanceById(id: String): Amplitude? {
             return pluginInstance?.instances?.get(id)

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -44,7 +44,6 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
          * @param id The instance name of the Amplitude instance.
          * @return The Amplitude instance or null if not found.
          */
-        @InternalAmplitudeApi
         @JvmStatic
         fun getAmplitudeInstanceById(id: String): Amplitude? {
             return pluginInstance?.instances?.get(id)
@@ -361,11 +360,3 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         return event
     }
 }
-
-@RequiresOptIn(
-    message = "This is an internal Amplitude API and is not intended for use outside of Amplitude SDKs.",
-    level = RequiresOptIn.Level.ERROR
-)
-@Retention(AnnotationRetention.BINARY)
-@Target(AnnotationTarget.FUNCTION)
-annotation class InternalAmplitudeApi

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -26,7 +26,7 @@ import java.lang.ref.WeakReference
 private var pluginInstance: AmplitudeFlutterPlugin? = null
 
 class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
-    private val instances: MutableMap<String, Amplitude> = mutableMapOf()
+    private var instances: Map<String, Amplitude> = mutableMapOf()
     private var activity: WeakReference<Activity?> = WeakReference(null)
     lateinit var ctxt: Context
     private var appOpenedTracked = false

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -19,7 +19,7 @@ internal var pluginInstance: SwiftAmplitudeFlutterPlugin?
     ///
     /// - parameter id: The instance name of the Amplitude instance.
     /// - returns: The Amplitude instance or `nil` if not found.
-    @_spi(AmplitudeFlutterPlugin) public static func getAmplitudeInstanceById(_ id: String) -> Amplitude? {
+    public static func getAmplitudeInstanceById(_ id: String) -> Amplitude? {
       guard let pluginInstance = pluginInstance else {
           return nil
       }

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -7,12 +7,24 @@ import FlutterMacOS
 
 import AmplitudeSwift
 
+internal var pluginInstance: SwiftAmplitudeFlutterPlugin? = nil
+
 @objc public class SwiftAmplitudeFlutterPlugin: NSObject, FlutterPlugin {
-    static var instances: [String: Amplitude] = [:]
+    var instances: [String: Amplitude] = [:]
     static let methodChannelName = "amplitude_flutter"
 
-    public static func findAmplitudeInstanceById(_ id: String) -> Amplitude? {
-        return instances[id]
+    /// Returns an Amplitude instance by its instance name.
+    /// This method is intended to be used by other Amplitude SDKs to be able to
+    /// access the underlying Amplitude instance from a native context.
+    ///
+    /// - parameter id: The instance name of the Amplitude instance.
+    /// - returns: The Amplitude instance or `nil` if not found.
+    @_spi(AmplitudeFlutterPlugin) public static func getAmplitudeInstanceById(_ id: String) -> Amplitude? {
+      guard let pluginInstance = pluginInstance else {
+          return nil
+      }
+
+      return pluginInstance.instances[id]
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -24,6 +36,7 @@ import AmplitudeSwift
         let channel = FlutterMethodChannel(name: methodChannelName, binaryMessenger: messenger)
         let instance = SwiftAmplitudeFlutterPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
+        pluginInstance = instance
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -36,7 +49,7 @@ import AmplitudeSwift
             var amplitude: Amplitude?
             do {
                 amplitude = Amplitude(configuration: try getConfiguration(args: configArgs))
-                Self.instances[amplitude!.configuration.instanceName] = amplitude
+                instances[amplitude!.configuration.instanceName] = amplitude
             } catch {
                 print("Initialization failed.")
             }
@@ -56,7 +69,7 @@ import AmplitudeSwift
 
         let arguments = call.arguments as? [String: Any]
         let instanceName = arguments?["instanceName"] as? String ?? "$default_instance"
-        let amplitude = Self.instances[instanceName]
+        let amplitude = instances[instanceName]
 
         switch call.method {
         case "track", "identify", "groupIdentify", "setGroup", "revenue":

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -8,8 +8,12 @@ import FlutterMacOS
 import AmplitudeSwift
 
 @objc public class SwiftAmplitudeFlutterPlugin: NSObject, FlutterPlugin {
-    var instances: [String: Amplitude] = [:]
+    static var instances: [String: Amplitude] = [:]
     static let methodChannelName = "amplitude_flutter"
+
+    public static func findAmplitudeInstanceById(_ id: String) -> Amplitude? {
+        return instances[id]
+    }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         #if os(iOS)
@@ -32,7 +36,7 @@ import AmplitudeSwift
             var amplitude: Amplitude?
             do {
                 amplitude = Amplitude(configuration: try getConfiguration(args: configArgs))
-                instances[amplitude!.configuration.instanceName] = amplitude
+                Self.instances[amplitude!.configuration.instanceName] = amplitude
             } catch {
                 print("Initialization failed.")
             }
@@ -52,7 +56,7 @@ import AmplitudeSwift
 
         let arguments = call.arguments as? [String: Any]
         let instanceName = arguments?["instanceName"] as? String ?? "$default_instance"
-        let amplitude = instances[instanceName]
+        let amplitude = Self.instances[instanceName]
 
         switch call.method {
         case "track", "identify", "groupIdentify", "setGroup", "revenue":

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -39,6 +39,10 @@ internal var pluginInstance: SwiftAmplitudeFlutterPlugin?
         pluginInstance = instance
     }
 
+    public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        pluginInstance = nil
+    }
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         if call.method == "init" {
             guard let configArgs = call.arguments as? [String: Any] else {

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -19,7 +19,7 @@ internal var pluginInstance: SwiftAmplitudeFlutterPlugin?
     ///
     /// - parameter id: The instance name of the Amplitude instance.
     /// - returns: The Amplitude instance or `nil` if not found.
-    public static func getAmplitudeInstanceById(_ id: String) -> Amplitude? {
+    @_spi(AmplitudeFlutterPlugin) public static func getAmplitudeInstanceById(_ id: String) -> Amplitude? {
       guard let pluginInstance = pluginInstance else {
           return nil
       }

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -7,7 +7,7 @@ import FlutterMacOS
 
 import AmplitudeSwift
 
-internal var pluginInstance: SwiftAmplitudeFlutterPlugin? = nil
+internal var pluginInstance: SwiftAmplitudeFlutterPlugin?
 
 @objc public class SwiftAmplitudeFlutterPlugin: NSObject, FlutterPlugin {
     var instances: [String: Amplitude] = [:]


### PR DESCRIPTION
**Context**
- Guides & Surveys / Engagement team have been working to bring these Amplitude SDKs more in line with the SDK plugin system
- Flutter is still a bit behind from this and we worked with the analytics SDK team to figure out how we can enable Guides & Surveys / Engagement to support this
- We were a bit limited because both G&S and Analytics SDKs work as a wrapper around the native instance
- We decided that we could expose a way for other SDK's to get the underlying `Amplitude` instance from the `instances` map to use and hook up in a native context.


**Changes**
- On both iOS and Android, I set up a global private variable to store the instance of the `Plugin` implementation we have. The FlutterEngine will only use a single instance.
- Then I added `getAmplitudeInstanceById` function to actually retrieve this from the global private var
- This will then get used by AmplitudeEngagement when setting up that SDK via plugin (ie. in dart `installAmplitudeEngagementPlugin(amplitude: Amplitude)`
- For more info on how this will be used, see this PR in G&S repo https://github.com/amplitude/amplitude-gs-mobile-sdk/pull/640



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces global plugin singletons on Android/iOS to expose the underlying `Amplitude` instances to other native SDKs, which could impact lifecycle/memory behavior if the engine attachment/detachment is mishandled.
> 
> **Overview**
> Enables other Amplitude Flutter SDKs to hook into the underlying native `Amplitude` instance by exposing a native `getAmplitudeInstanceById(instanceName)` accessor on both Android and Darwin.
> 
> Android stores a global `pluginInstance` for the engine lifecycle and adds an `androidx.annotation` dependency to scope the new API as library-internal. Documentation is updated with internal guidance on integrating additional Flutter SDKs/plugins via the retrieved native instance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48a000de2a99b2a7085e743bfda89f5d8fbc1433. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->