### PR TITLE
feat: add setOptOut support for iOS and Android

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -162,6 +162,19 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
                 result.success(sessionId)
             }
 
+            "setOptOut" -> {
+                val enabled = call.argument<Map<String, Boolean>>("properties")?.get("setOptOut")
+                if (enabled != null) {
+                    amplitude.configuration.optOut = enabled
+                    amplitude.logger.debug("Set optOut to $enabled")
+                } else {
+                    amplitude.logger.warn("setOptOut type casting to Bool failed.")
+                    return
+                }
+
+                result.success("setOptOut called..")
+            }
+
             "reset" -> {
                 amplitude.reset()
                 amplitude.logger.debug("Reset userId and deviceId.")

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -165,7 +165,7 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             "setOptOut" -> {
                 val enabled = call.argument<Map<String, Boolean>>("properties")?.get("setOptOut")
                 if (enabled != null) {
-                    amplitude.configuration.optOut = enabled
+                    amplitude.optOut = enabled
                     amplitude.logger.debug("Set optOut to $enabled")
                 } else {
                     amplitude.logger.warn("setOptOut type casting to Bool failed.")

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -155,7 +155,7 @@ internal var pluginInstance: SwiftAmplitudeFlutterPlugin?
                 return
             }
             if let enabled = args["setOptOut"] as? Bool {
-                amplitude?.configuration.optOut = enabled
+                amplitude?.optOut = enabled
                 amplitude?.logger?.debug(message: "Set optOut to \(enabled)")
             } else {
                 amplitude?.logger?.warn(message: "setOptOut type casting to Bool failed.")

--- a/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/Classes/SwiftAmplitudeFlutterPlugin.swift
@@ -149,6 +149,21 @@ internal var pluginInstance: SwiftAmplitudeFlutterPlugin?
 
             result(sessionId)
 
+        case "setOptOut":
+            guard let args = arguments?["properties"] as? [String: Any] else {
+                print("\(call.method) called but call.arguments type casting failed.")
+                return
+            }
+            if let enabled = args["setOptOut"] as? Bool {
+                amplitude?.configuration.optOut = enabled
+                amplitude?.logger?.debug(message: "Set optOut to \(enabled)")
+            } else {
+                amplitude?.logger?.warn(message: "setOptOut type casting to Bool failed.")
+                return
+            }
+
+            result("setOptOut called..")
+
         case "reset":
             amplitude?.reset()
             amplitude?.logger?.debug(message: "Reset userId and deviceId.")

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -99,6 +99,30 @@ class _MyAppState extends State<MyApp> {
                 divider,
                 // FlushThresholdForm(),
                 // divider,
+                Row(
+                  children: [
+                    Expanded(
+                      child: ElevatedButton(
+                        child: const Text('Opt Out'),
+                        onPressed: () {
+                          analytics.setOptOut(true);
+                          setMessage('Opted out — tracking disabled.');
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: ElevatedButton(
+                        child: const Text('Opt In'),
+                        onPressed: () {
+                          analytics.setOptOut(false);
+                          setMessage('Opted in — tracking enabled.');
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                divider,
                 ElevatedButton(
                   child: const Text('Flush Events'),
                   onPressed: _flushEvents,

--- a/lib/amplitude.dart
+++ b/lib/amplitude.dart
@@ -247,7 +247,6 @@ class Amplitude {
         'getSessionId', {'instanceName': configuration.instanceName});
   }
 
-  /// Web only.
   /// Disables tracking.
   ///
   /// Set setOptOut to true to disable logging for a specific user.


### PR DESCRIPTION
Previously setOptOut was only implemented for web. This adds native handling of the setOptOut method channel call on both iOS (Swift) and Android (Kotlin), allowing Flutter apps to disable/enable tracking on all platforms.

On iOS and Android SDKs, there is no `setOptOut` method, and rely on directly changing the `optOut` value on the Amplitude object.

Closes #293 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds native handling that toggles Amplitude’s `optOut` flag, directly affecting whether events are recorded/sent on mobile platforms. Risk is moderate since incorrect argument parsing or state handling could unintentionally disable (or re-enable) analytics tracking.
> 
> **Overview**
> Adds cross-platform `setOptOut` support by wiring the Flutter method-channel call through to native SDKs on **Android (Kotlin)** and **iOS (Swift)**, setting the underlying Amplitude instance’s `optOut` flag with basic type-checking and logging.
> 
> Updates the example app UI with **Opt Out / Opt In** buttons to exercise the new API, and removes the outdated *“Web only”* note from the Dart `setOptOut` documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8deb7dd39532294e00af47ef9cd7f50d50c34ed8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->