### PR TITLE
fix: update kotlin SDK to 1.27

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,10 +46,10 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.10"
 
-    // Locked to specific version to prevent binary compatibility issues.
+    // Locked to specific minor version to prevent binary compatibility issues.
     // Version range [1.22,2.0) previously caused NoSuchMethodError when Gradle
     // resolved different versions at compile-time vs runtime (see #283).
-    implementation 'com.amplitude:analytics-android:1.25.3'
+    implementation 'com.amplitude:analytics-android:1.27.+'
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation "io.mockk:mockk:1.12.4"
     testImplementation "io.mockk:mockk-agent-jvm:1.11.0"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.10"
 
     // Locked to specific minor version to prevent binary compatibility issues.
-    // Version range [1.22,2.0) previously caused NoSuchMethodError when Gradle
-    // resolved different versions at compile-time vs runtime (see #283).
+    // Allowing newer minor versions previously caused NoSuchMethodError due to
+    // compile-time vs runtime version mismatches (see #283).
     implementation 'com.amplitude:analytics-android:1.27.+'
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation "io.mockk:mockk:1.12.4"

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -3,8 +3,9 @@ package com.amplitude.amplitude_flutter
 import android.app.Activity
 import android.content.Context
 import com.amplitude.android.Amplitude
+import com.amplitude.android.AutocaptureOption
 import com.amplitude.android.Configuration
-import com.amplitude.android.DefaultTrackingOptions
+import com.amplitude.android.ConfigurationBuilder
 import com.amplitude.android.TrackingOptions
 import com.amplitude.android.events.IngestionMetadata
 import com.amplitude.android.events.Plan
@@ -83,8 +84,8 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
             trackAppLifecycleAndDeepLinkEvents(
                 amplitude,
-                configuration.defaultTracking.appLifecycles,
-                configuration.defaultTracking.deepLinks
+                AutocaptureOption.APP_LIFECYCLES in configuration.autocapture,
+                AutocaptureOption.DEEP_LINKS in configuration.autocapture
             )
 
             result.success("init called..")
@@ -188,45 +189,46 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     }
 
     private fun getConfiguration(call: MethodCall): Configuration {
-        val configuration = Configuration(call.argument<String>("apiKey")!!, context = ctxt)
-        call.argument<Int>("flushQueueSize")?.let { configuration.flushQueueSize = it }
-        call.argument<Int>("flushIntervalMillis")?.let { configuration.flushIntervalMillis = it }
-        call.argument<String>("instanceName")?.let { configuration.instanceName = it }
-        call.argument<Boolean>("optOut")?.let { configuration.optOut = it }
-        call.argument<Int>("minIdLength")?.let { configuration.minIdLength = it }
-        call.argument<String>("partnerId")?.let { configuration.partnerId = it }
-        call.argument<Int>("flushMaxRetries")?.let { configuration.flushMaxRetries = it }
-        call.argument<Boolean>("useBatch")?.let { configuration.useBatch = it }
+        val builder = ConfigurationBuilder(call.argument<String>("apiKey")!!, context = ctxt)
+        call.argument<Int>("flushQueueSize")?.let { builder.flushQueueSize = it }
+        call.argument<Int>("flushIntervalMillis")?.let { builder.flushIntervalMillis = it }
+        call.argument<String>("instanceName")?.let { builder.instanceName = it }
+        call.argument<Boolean>("optOut")?.let { builder.optOut = it }
+        call.argument<Int>("minIdLength")?.let { builder.minIdLength = it }
+        call.argument<String>("partnerId")?.let { builder.partnerId = it }
+        call.argument<Int>("flushMaxRetries")?.let { builder.flushMaxRetries = it }
+        call.argument<Boolean>("useBatch")?.let { builder.useBatch = it }
         call.argument<String>("serverZone")
-            ?.let { configuration.serverZone = com.amplitude.core.ServerZone.valueOf(it.uppercase()) }
-        call.argument<String>("serverUrl")?.let { configuration.serverUrl = it }
+            ?.let { builder.serverZone = com.amplitude.core.ServerZone.valueOf(it.uppercase()) }
+        call.argument<String>("serverUrl")?.let { builder.serverUrl = it }
         call.argument<Int>("minTimeBetweenSessionsMillis")
-            ?.let { configuration.minTimeBetweenSessionsMillis = it.toLong() }
+            ?.let { builder.minTimeBetweenSessionsMillis = it.toLong() }
         call.argument<Map<String, Any>>("defaultTracking")?.let { map ->
-            configuration.defaultTracking = DefaultTrackingOptions(
-                sessions = (map["sessions"] as? Boolean) ?: true,
-                appLifecycles = (map["appLifecycles"] as? Boolean) ?: false,
-                deepLinks = (map["deepLinks"] as? Boolean) ?: false,
-                // Set false to disable screenViews on Android
-                // screenViews is implemented in Flutter
-                screenViews = false
-            )
+            val sessions = (map["sessions"] as? Boolean) ?: true
+            val appLifecycles = (map["appLifecycles"] as? Boolean) ?: false
+            val deepLinks = (map["deepLinks"] as? Boolean) ?: false
+            // screenViews is always disabled on Android — implemented in Flutter
+            builder.autocapture = buildSet {
+                if (sessions) add(AutocaptureOption.SESSIONS)
+                if (appLifecycles) add(AutocaptureOption.APP_LIFECYCLES)
+                if (deepLinks) add(AutocaptureOption.DEEP_LINKS)
+            }
         }
         call.argument<Map<String, Any>>("trackingOptions")?.let { map ->
-            configuration.trackingOptions = convertMapToTrackingOptions(map)
+            builder.trackingOptions = convertMapToTrackingOptions(map)
         }
-        call.argument<Boolean>("enableCoppaControl")?.let { configuration.enableCoppaControl = it }
-        call.argument<Boolean>("flushEventsOnClose")?.let { configuration.flushEventsOnClose = it }
+        call.argument<Boolean>("enableCoppaControl")?.let { builder.enableCoppaControl = it }
+        call.argument<Boolean>("flushEventsOnClose")?.let { builder.flushEventsOnClose = it }
         call.argument<Int>("identifyBatchIntervalMillis")
-            ?.let { configuration.identifyBatchIntervalMillis = it.toLong() }
-        call.argument<Boolean>("migrateLegacyData")?.let { configuration.migrateLegacyData = it }
-        call.argument<Boolean>("locationListening")?.let { configuration.locationListening = it }
+            ?.let { builder.identifyBatchIntervalMillis = it.toLong() }
+        call.argument<Boolean>("migrateLegacyData")?.let { builder.migrateLegacyData = it }
+        call.argument<Boolean>("locationListening")?.let { builder.locationListening = it }
         call.argument<Boolean>("useAdvertisingIdForDeviceId")
-            ?.let { configuration.useAdvertisingIdForDeviceId = it }
-        call.argument<Boolean>("useAppSetIdForDeviceId")?.let { configuration.useAppSetIdForDeviceId = it }
-        call.argument<String>("deviceId")?.let { configuration.deviceId = it }
+            ?.let { builder.useAdvertisingIdForDeviceId = it }
+        call.argument<Boolean>("useAppSetIdForDeviceId")?.let { builder.useAppSetIdForDeviceId = it }
+        call.argument<String>("deviceId")?.let { builder.deviceId = it }
 
-        return configuration
+        return builder.build()
     }
 
     private fun convertMapToTrackingOptions(map: Map<String, Any>): TrackingOptions {


### PR DESCRIPTION
- this should use the config builder which has a safer constructor than config object


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Amplitude Android SDK dependency resolution and the plugin’s initialization/config mapping, which can alter runtime behavior (autocapture flags, batching/session tracking) if the builder semantics differ or a newer 1.27.x release is pulled in.
> 
> **Overview**
> Updates the Android dependency pin from a fixed `com.amplitude:analytics-android:1.25.3` to the `1.27.+` minor line to reduce binary-compatibility issues while allowing patch updates.
> 
> Refactors plugin initialization to build SDK configuration via `ConfigurationBuilder` (instead of mutating a `Configuration` instance), and maps `defaultTracking` into the SDK’s `autocapture` set (`SESSIONS`, `APP_LIFECYCLES`, `DEEP_LINKS`), updating lifecycle/deeplink tracking checks accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 337e5016e4f07da7281f9fb5e39688f086912682. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->