### PR TITLE
chore: unlock iOS AmplitudeSwift to allow patch updates

### DIFF
--- a/darwin/amplitude_flutter.podspec
+++ b/darwin/amplitude_flutter.podspec
@@ -32,5 +32,5 @@ The official Amplitude Flutter SDK for tracking analytics events in your Flutter
     'DEBUG_INFORMATION_FORMAT' => 'dwarf-with-dsym'
   }
   s.swift_version = '5.9'
-  s.dependency 'AmplitudeSwift', '1.17.3'
+  s.dependency 'AmplitudeSwift', '~> 1.17.5'
 end


### PR DESCRIPTION
## Summary
- Changes AmplitudeSwift dependency from exact pin (`1.17.3`) to pessimistic operator (`~> 1.17.5`), allowing automatic patch bumps `>= 1.17.5, < 1.18.0`
- Bumps minimum version from 1.17.3 to 1.17.5

## Test plan
- [ ] Verify `pod install` resolves AmplitudeSwift 1.17.5
- [ ] Run iOS example app and confirm SDK initializes correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the iOS/macOS podspec dependency constraint, but could surface upstream patch regressions when resolving pods.
> 
> **Overview**
> Relaxes the `AmplitudeSwift` CocoaPods dependency in `darwin/amplitude_flutter.podspec` from an exact pin to `~> 1.17.5`, bumping the minimum version and allowing automatic patch updates within the `1.17.x` line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32df0ed5861341b4758302e82b892febc2118672. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->