### PR TITLE
chore: SECENG-7706 [security] Pin versions of GitHub Actions to full commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: 'stable'
 

--- a/.github/workflows/jira-issue-create.yml
+++ b/.github/workflows/jira-issue-create.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   call-workflow-passing-data:
-    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@main
+    uses: amplitude/Amplitude-TypeScript/.github/workflows/jira-issue-create-template.yml@c832303a64c05b9911b6b1ad3dd8f69099f71179 # @amplitude/analytics-browser@2.36.9
     with:
       label: "Flutter"
       subcomponent: "dx_flutter_sdk"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,17 +16,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       # This step sets the GitHub-signed OIDC token for pub.dev
       # Workaround for https://github.com/dart-lang/setup-dart/issues/68
       - name: Setup Dart
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1
         with:
           sdk: stable
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: 'stable'
           cache: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,12 @@ jobs:
     needs: [authorize]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
           channel: 'stable'
           cache: true

--- a/.github/workflows/swift-lint.yml
+++ b/.github/workflows/swift-lint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: macos-14-large
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Set Xcode 16
         run: |


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hash via automated scripts.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

This pull request was created by [multi-gitter](https://github.com/lindell/multi-gitter).

Please merge this pull request by 2026-04-10.

For any questions, please ask in the Slack channel #help-security.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only pins existing GitHub Action references to immutable commit SHAs (and fixes a missing newline), with no functional workflow logic changes expected.
> 
> **Overview**
> Pins GitHub Actions in workflow files to immutable commit SHAs (e.g., `actions/checkout`, `subosito/flutter-action`, `dart-lang/setup-dart`) and pins the Jira reusable workflow reference to a specific commit.
> 
> No behavioral workflow changes are intended beyond making runs more supply-chain resilient; also normalizes the trailing newline in `ci.yml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4112db76aa01ea3eafb66a7ad11e0dced9b2a35f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->