### PR TITLE
chore: add test-sdk agent skill for E2E smoke testing

### DIFF
--- a/.claude/skills/test-sdk/CHANGELOG.md
+++ b/.claude/skills/test-sdk/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog -- test-sdk
+
+## 1.3.0 (2026-04-04)
+
+- Switch to self-reading subagent pattern: subagents read their own instruction
+  files instead of receiving them inline from the orchestrator. Reduces main
+  agent context by ~600 lines per run.
+- Add `{SKILL_ROOT}` variable for unambiguous file paths across all subagents.
+- Add structured error handling for missing instruction files.
+- Fix: cleanup no longer unconditionally disables SPM. Only resets flutter
+  config when iOS platforms were actually tested (SPM config is global and
+  persists across sessions).
+- Add `{PLATFORMS_TESTED}` variable to cleanup subagent.
+
+## 1.2.0 (2026-03-31)
+
+- Use `--dart-define-from-file=.env` for API key injection instead of sed.
+- Add `String.fromEnvironment('AMPLITUDE_API_KEY')` to example main.dart.
+- Add interactive `amplitude-project.local.yaml` creation flow (ask-then-save).
+- Simplify cleanup (no more API key revert in main.dart).
+- Gitignore `example/.env` and `example/amplitude-project.local.yaml`.
+
+## 1.1.0 (2026-03-31)
+
+- Extract subagent prompts from SKILL.md into `agents/` directory.
+- Reduce SKILL.md from ~469 lines to ~129 lines.
+- Add `allowed-tools` to frontmatter.
+
+## 1.0.0 (2026-03-31)
+
+- Initial release: E2E smoke-test orchestrator for Amplitude Flutter SDK.
+- Pre-flight checks, multi-platform build, mobile/web testing, Amplitude
+  event verification, and cleanup.

--- a/.claude/skills/test-sdk/SKILL.md
+++ b/.claude/skills/test-sdk/SKILL.md
@@ -13,7 +13,7 @@ compatibility:
   - claude-code
   - codex
 allowed-tools: >-
-  Read Task AskQuestion CallMcpTool Shell Glob Grep
+  Read Write StrReplace Task AskQuestion CallMcpTool Shell Glob Grep
 metadata:
   version: "1.1.0"
   created: "2026-03-31"
@@ -57,8 +57,8 @@ Launch as a `fast` generalPurpose subagent.
 Run on the **main agent** (not a subagent). Use AskQuestion.
 
 **Question 1 -- run mode:**
-- "Default smoke test (iOS + Android + Web)" -- sets platforms to all, flow
-  to `basic-event`, skips to Phase 3 with zero follow-ups.
+- "Default smoke test (iOS SPM, iOS CocoaPods, Android, Web)" -- sets all 4
+  platforms, flow to `basic-event`, skips to Phase 3 with zero follow-ups.
 - "Customize" -- ask Questions 2 and 3.
 
 **Question 2 -- platforms** (only if custom, multi-select):
@@ -71,7 +71,7 @@ modification.
 
 ## Phase 3: Build
 
-Read `agents/build.md`. Fill `{PLATFORMS}` and `{PLATFORM_FLUTTER_MD_CONTENTS}`
+Read `agents/build.md`. Fill `{REPO_ROOT}`, `{PLATFORMS}`, and `{PLATFORM_FLUTTER_MD_CONTENTS}`
 (paste the full contents of `platform-flutter.md`). Launch as a `fast` shell
 subagent.
 

--- a/.claude/skills/test-sdk/SKILL.md
+++ b/.claude/skills/test-sdk/SKILL.md
@@ -15,7 +15,7 @@ compatibility:
 allowed-tools: >-
   Read Write StrReplace Task AskQuestion CallMcpTool Shell Glob Grep
 metadata:
-  version: "1.2.0"
+  version: "1.3.0"
   created: "2026-03-31"
 ---
 
@@ -31,22 +31,41 @@ This skill is a **conversation-local smoke check** -- no external test runner
 dependencies (no Appium, no WDIO, no Node). It complements the CI-grade
 Appium/WebdriverIO E2E harness for interactive pre-PR validation.
 
-## Reference Files
+## Architecture: Self-Reading Subagents
 
-Read these from this skill directory before starting:
+Subagent instruction files live in `agents/`. The main agent does NOT read
+these files. Instead, each phase launches a subagent with a compact delegation
+prompt that tells it to read its own instruction file. This keeps the main
+agent's context lean (~130 lines vs ~930 lines).
+
+Reference files (read by subagents, not the main agent):
 
 - `platform-flutter.md` -- build commands, paths, app IDs, known issues
-- `amplitude-project.md` -- Amplitude project config template, token clearing instructions
+- `amplitude-project.md` -- Amplitude project config template, token clearing
 - `test-flows.md` -- structured test scenarios with UI elements and expected events
 
-Subagent prompts live in `agents/`. Read the relevant file and fill its
-`{VARIABLES}` before passing as the subagent prompt.
+### Delegation prompt contract
+
+Every subagent delegation prompt follows this structure:
+
+1. "Step 1: Read `{SKILL_ROOT}/agents/<file>.md` for your full instructions."
+2. Additional reference files to read.
+3. Variable values (short runtime strings only).
+4. "Return the expected YAML output format defined in the instruction file."
+5. "If any file is not found, return: status: fail, error: 'File not found: <path>'."
+
+`SKILL_ROOT` is the absolute path to `.claude/skills/test-sdk` in the current
+workspace. Determine it once at the start of the run.
 
 ## Phase 1: Pre-flight
 
-Read `agents/preflight.md`. Fill `{REPO_ROOT}` with the absolute repo path and
-`{TOKEN_CLEARING_INSTRUCTIONS}` from `amplitude-project.md`. Launch as a `fast`
-generalPurpose subagent.
+Launch a `fast` generalPurpose subagent with this prompt:
+
+  "Step 1: Read `{SKILL_ROOT}/agents/preflight.md` for your full instructions.
+   Step 2: Read `{SKILL_ROOT}/amplitude-project.md` for token-clearing instructions.
+   Variable values: REPO_ROOT={absolute repo path}, SKILL_ROOT={skill root path}.
+   Follow the instructions, fill variables, and return the expected YAML output.
+   If any file is not found, return: status: fail, error: 'File not found: <path>'."
 
 **Result handling:**
 - `preflight_status: fail` -- stop, report failures. Do not proceed.
@@ -76,9 +95,14 @@ modification.
 
 ## Phase 3: Build
 
-Read `agents/build.md`. Fill `{REPO_ROOT}`, `{PLATFORMS}`, and `{PLATFORM_FLUTTER_MD_CONTENTS}`
-(paste the full contents of `platform-flutter.md`). Launch as a `fast` shell
-subagent.
+Launch a `fast` shell subagent with this prompt:
+
+  "Step 1: Read `{SKILL_ROOT}/agents/build.md` for your full instructions.
+   Step 2: Read `{SKILL_ROOT}/platform-flutter.md` for platform build commands.
+   Variable values: REPO_ROOT={absolute repo path}, PLATFORMS={selected platforms},
+   SKILL_ROOT={skill root path}.
+   Follow the instructions and return the expected YAML output.
+   If any file is not found, return: status: fail, error: 'File not found: <path>'."
 
 The API key is injected at compile time via `--dart-define-from-file=.env`
 (already configured in the build commands). No file modification needed.
@@ -90,17 +114,39 @@ The API key is injected at compile time via `--dart-define-from-file=.env`
 
 ## Phase 4: Test
 
-Read `agents/test-mobile.md` (for iOS/Android) and `agents/test-web.md` (for
-Web). Fill variables from build results and the selected test flow from
-`test-flows.md`. Launch **all in parallel** as `fast` generalPurpose subagents.
+Launch subagents **in parallel** for each platform:
+
+**For each mobile platform** (iOS/Android), launch a `fast` generalPurpose subagent:
+
+  "Step 1: Read `{SKILL_ROOT}/agents/test-mobile.md` for your full instructions.
+   Step 2: Read `{SKILL_ROOT}/test-flows.md` for test scenarios.
+   Variable values: PLATFORM={platform id}, DEVICE_ID={device id},
+   ARTIFACT_PATH={built app path}, APP_ID={bundle/package id},
+   TEST_FLOW_NAME={selected flow name}, SKILL_ROOT={skill root path}.
+   Follow the instructions and return the expected YAML output.
+   If any file is not found, return: status: fail, error: 'File not found: <path>'."
+
+**For Web**, launch a `fast` generalPurpose subagent:
+
+  "Step 1: Read `{SKILL_ROOT}/agents/test-web.md` for your full instructions.
+   Step 2: Read `{SKILL_ROOT}/test-flows.md` for test scenarios.
+   Variable values: REPO_ROOT={absolute repo path},
+   TEST_FLOW_NAME={selected flow name}, SKILL_ROOT={skill root path}.
+   Follow the instructions and return the expected YAML output.
+   If any file is not found, return: status: fail, error: 'File not found: <path>'."
 
 **Result handling:** Collect all subagent results. Merge `expected_events`.
 
 ## Phase 5: Verify
 
-Read `agents/verify.md`. Fill `{PROJECT_ID}` from `example/amplitude-project.local.yaml` and
-`{EXPECTED_EVENTS_YAML}` from Phase 4 results. Launch as a `fast`
-generalPurpose subagent.
+Launch a `fast` generalPurpose subagent with this prompt:
+
+  "Step 1: Read `{SKILL_ROOT}/agents/verify.md` for your full instructions.
+   Variable values: PROJECT_ID={id from local yaml},
+   EXPECTED_EVENTS_YAML={merged events yaml from Phase 4},
+   SKILL_ROOT={skill root path}.
+   Follow the instructions and return the expected YAML output.
+   If any file is not found, return: status: fail, error: 'File not found: <path>'."
 
 **Result handling:**
 - All found: report success.
@@ -108,8 +154,13 @@ generalPurpose subagent.
 
 ## Phase 6: Cleanup
 
-Read `agents/cleanup.md`. No variables to fill. Launch as a `fast` shell
-subagent.
+Launch a `fast` shell subagent with this prompt:
+
+  "Step 1: Read `{SKILL_ROOT}/agents/cleanup.md` for your full instructions.
+   Variable values: PLATFORMS_TESTED={comma-separated platforms from Phase 2},
+   SKILL_ROOT={skill root path}.
+   Follow the instructions and return the expected YAML output.
+   If any file is not found, return: status: fail, error: 'File not found: <path>'."
 
 ## Final Report
 
@@ -129,6 +180,7 @@ with screenshot paths.
 ## Error Handling
 
 - **Subagent timeout**: include partial results, note in report.
+- **Instruction file not found**: treat as phase failure, report the missing path.
 - **MCP connection loss**: retry once, then skip with explanation.
 - **Build failure**: skip that platform's test, continue others.
 - **Device crash**: capture last screenshot, report partial.

--- a/.claude/skills/test-sdk/SKILL.md
+++ b/.claude/skills/test-sdk/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: test-sdk
+description: >-
+  E2E smoke-test the Amplitude Flutter SDK on real simulators/emulators.
+  Runs pre-flight checks, builds for selected platforms (iOS SPM, iOS CocoaPods,
+  Android, Web), executes test flows via mobile-mcp and browser MCP, then
+  verifies events landed in Amplitude. Use when testing SDK changes before
+  a release or after modifying native plugin code.
+  Triggers on: "test the SDK", "smoke test", "test my changes", "run E2E",
+  "test on all platforms", "verify events".
+compatibility:
+  - cursor
+  - claude-code
+  - codex
+allowed-tools: >-
+  Read Task AskQuestion CallMcpTool Shell Glob Grep
+metadata:
+  version: "1.1.0"
+  created: "2026-03-31"
+---
+
+# test-sdk
+
+Lightweight, agent-native E2E smoke-test orchestrator for the Amplitude Flutter
+SDK. All heavy work is delegated to `fast` subagents to conserve main agent
+context.
+
+## Design Rationale
+
+This skill is a **conversation-local smoke check** -- no external test runner
+dependencies (no Appium, no WDIO, no Node). It complements the CI-grade
+Appium/WebdriverIO E2E harness for interactive pre-PR validation.
+
+## Reference Files
+
+Read these from this skill directory before starting:
+
+- `platform-flutter.md` -- build commands, paths, app IDs, known issues
+- `amplitude-project.md` -- Amplitude project config, API key, org, token clearing
+- `test-flows.md` -- structured test scenarios with UI elements and expected events
+
+Subagent prompts live in `agents/`. Read the relevant file and fill its
+`{VARIABLES}` before passing as the subagent prompt.
+
+## Phase 1: Pre-flight
+
+Read `agents/preflight.md`. Fill variables from `amplitude-project.md`.
+Launch as a `fast` generalPurpose subagent.
+
+**Result handling:**
+- `preflight_status: fail` -- stop, report failures. Do not proceed.
+- Any `warn` -- show warnings, ask user to continue via AskQuestion.
+- All `pass` -- proceed to Phase 2.
+
+## Phase 2: Interactive Planning
+
+Run on the **main agent** (not a subagent). Use AskQuestion.
+
+**Question 1 -- run mode:**
+- "Default smoke test (iOS + Android + Web)" -- sets platforms to all, flow
+  to `basic-event`, skips to Phase 3 with zero follow-ups.
+- "Customize" -- ask Questions 2 and 3.
+
+**Question 2 -- platforms** (only if custom, multi-select):
+iOS SPM, iOS CocoaPods, Android, Web.
+
+**Question 3 -- test flow** (only if custom, single-select):
+basic-event, identify, revenue, set-group, full-smoke, or "Custom -- I'll
+describe it." If custom, ask what to test and whether the example app needs
+modification.
+
+## Phase 3: Build
+
+Read `agents/build.md`. Fill `{PLATFORMS}` and `{PLATFORM_FLUTTER_MD_CONTENTS}`
+(paste the full contents of `platform-flutter.md`). Launch as a `fast` shell
+subagent.
+
+Before launching, set the API key in `example/lib/main.dart` using StrReplace.
+
+**Result handling:**
+- All built: proceed to Phase 4 with all platforms.
+- Some failed: proceed with passing platforms, note failures.
+- All failed: stop and report.
+
+## Phase 4: Test
+
+Read `agents/test-mobile.md` (for iOS/Android) and `agents/test-web.md` (for
+Web). Fill variables from build results and the selected test flow from
+`test-flows.md`. Launch **all in parallel** as `fast` generalPurpose subagents.
+
+**Result handling:** Collect all subagent results. Merge `expected_events`.
+
+## Phase 5: Verify
+
+Read `agents/verify.md`. Fill `{PROJECT_ID}` from `amplitude-project.md` and
+`{EXPECTED_EVENTS_YAML}` from Phase 4 results. Launch as a `fast`
+generalPurpose subagent.
+
+**Result handling:**
+- All found: report success.
+- Some missing after 5 min: report as "unverified" (not "failed").
+
+## Phase 6: Cleanup
+
+Read `agents/cleanup.md`. Launch as a `fast` shell subagent.
+
+## Final Report
+
+Present a summary table:
+
+```
+| Platform      | Build  | Test    | Events Verified |
+|---------------|--------|---------|-----------------|
+| iOS SPM       | pass   | pass    | yes             |
+| Android       | pass   | partial | yes             |
+| Web           | pass   | pass    | yes             |
+```
+
+Include: verification wait time, cleanup status, any warnings or failures
+with screenshot paths.
+
+## Error Handling
+
+- **Subagent timeout**: include partial results, note in report.
+- **MCP connection loss**: retry once, then skip with explanation.
+- **Build failure**: skip that platform's test, continue others.
+- **Device crash**: capture last screenshot, report partial.
+- **Amplitude delay**: poll up to 5 min with exponential backoff.
+- **Native dialogs**: subagents dismiss/accept. If unhandled, screenshot + fail step.

--- a/.claude/skills/test-sdk/SKILL.md
+++ b/.claude/skills/test-sdk/SKILL.md
@@ -102,7 +102,9 @@ generalPurpose subagent.
 
 ## Phase 6: Cleanup
 
-Read `agents/cleanup.md`. Launch as a `fast` shell subagent.
+Read `agents/cleanup.md`. Fill `{API_KEY_PLACEHOLDER}` with `API_KEY` (the
+literal placeholder string from `example/lib/main.dart`). Launch as a `fast`
+shell subagent.
 
 ## Final Report
 

--- a/.claude/skills/test-sdk/SKILL.md
+++ b/.claude/skills/test-sdk/SKILL.md
@@ -15,7 +15,7 @@ compatibility:
 allowed-tools: >-
   Read Write StrReplace Task AskQuestion CallMcpTool Shell Glob Grep
 metadata:
-  version: "1.1.0"
+  version: "1.2.0"
   created: "2026-03-31"
 ---
 
@@ -36,7 +36,7 @@ Appium/WebdriverIO E2E harness for interactive pre-PR validation.
 Read these from this skill directory before starting:
 
 - `platform-flutter.md` -- build commands, paths, app IDs, known issues
-- `amplitude-project.md` -- Amplitude project config, API key, org, token clearing
+- `amplitude-project.md` -- Amplitude project config template, token clearing instructions
 - `test-flows.md` -- structured test scenarios with UI elements and expected events
 
 Subagent prompts live in `agents/`. Read the relevant file and fill its
@@ -44,13 +44,18 @@ Subagent prompts live in `agents/`. Read the relevant file and fill its
 
 ## Phase 1: Pre-flight
 
-Read `agents/preflight.md`. Fill variables from `amplitude-project.md`.
-Launch as a `fast` generalPurpose subagent.
+Read `agents/preflight.md`. Fill `{REPO_ROOT}` with the absolute repo path and
+`{TOKEN_CLEARING_INSTRUCTIONS}` from `amplitude-project.md`. Launch as a `fast`
+generalPurpose subagent.
 
 **Result handling:**
 - `preflight_status: fail` -- stop, report failures. Do not proceed.
+- `config_needed: true` -- the local project config is missing. Ask the user
+  in chat for their Amplitude project ID, org name, and org ID. Create
+  `example/amplitude-project.local.yaml` with those values. Then proceed.
 - Any `warn` -- show warnings, ask user to continue via AskQuestion.
-- All `pass` -- proceed to Phase 2.
+- All `pass` -- proceed to Phase 2. Save `project_config` from output for
+  use in Phase 5.
 
 ## Phase 2: Interactive Planning
 
@@ -75,7 +80,8 @@ Read `agents/build.md`. Fill `{REPO_ROOT}`, `{PLATFORMS}`, and `{PLATFORM_FLUTTE
 (paste the full contents of `platform-flutter.md`). Launch as a `fast` shell
 subagent.
 
-Before launching, set the API key in `example/lib/main.dart` using StrReplace.
+The API key is injected at compile time via `--dart-define-from-file=.env`
+(already configured in the build commands). No file modification needed.
 
 **Result handling:**
 - All built: proceed to Phase 4 with all platforms.
@@ -92,7 +98,7 @@ Web). Fill variables from build results and the selected test flow from
 
 ## Phase 5: Verify
 
-Read `agents/verify.md`. Fill `{PROJECT_ID}` from `amplitude-project.md` and
+Read `agents/verify.md`. Fill `{PROJECT_ID}` from `example/amplitude-project.local.yaml` and
 `{EXPECTED_EVENTS_YAML}` from Phase 4 results. Launch as a `fast`
 generalPurpose subagent.
 
@@ -102,9 +108,8 @@ generalPurpose subagent.
 
 ## Phase 6: Cleanup
 
-Read `agents/cleanup.md`. Fill `{API_KEY_PLACEHOLDER}` with `API_KEY` (the
-literal placeholder string from `example/lib/main.dart`). Launch as a `fast`
-shell subagent.
+Read `agents/cleanup.md`. No variables to fill. Launch as a `fast` shell
+subagent.
 
 ## Final Report
 

--- a/.claude/skills/test-sdk/agents/build.md
+++ b/.claude/skills/test-sdk/agents/build.md
@@ -14,7 +14,12 @@ Task tool:
 
 - `{REPO_ROOT}` -- absolute path to the repository root
 - `{PLATFORMS}` -- comma-separated list of selected platform IDs
-- `{PLATFORM_FLUTTER_MD_CONTENTS}` -- full contents of `platform-flutter.md`
+- `{SKILL_ROOT}` -- absolute path to the skill directory
+
+## Self-Read References
+
+Read this file before building:
+- `{SKILL_ROOT}/platform-flutter.md` -- platform build commands, paths, known issues
 
 ## Prompt
 
@@ -27,18 +32,18 @@ IMPORTANT: Cap your response to 3000 characters. Save build logs to
 
 Selected platforms: {PLATFORMS}
 
+Step 1: Read `{SKILL_ROOT}/platform-flutter.md` for platform-specific build
+commands, output paths, and known issues.
+
 All flutter build commands MUST include --dart-define-from-file=.env to inject
 the Amplitude API key at compile time. The .env file is in the working directory.
 Do NOT read, echo, or log the contents of the .env file.
 
-For each platform, follow the build commands from the platform reference below.
 Key rules:
 - iOS SPM and iOS CocoaPods builds MUST be sequential (flutter config is global)
 - Run `flutter clean && flutter pub get` between iOS build variants
 - Android and Web builds can run alongside iOS
 - If a build fails, log the error and continue with remaining platforms
-
-{PLATFORM_FLUTTER_MD_CONTENTS}
 ```
 
 ## Expected Output

--- a/.claude/skills/test-sdk/agents/build.md
+++ b/.claude/skills/test-sdk/agents/build.md
@@ -1,0 +1,53 @@
+# Build Subagent
+
+Builds the Flutter example app for selected platforms.
+
+## Invocation
+
+```
+Task tool:
+  subagent_type: "shell"
+  model: "fast"
+```
+
+## Input Variables
+
+- `{REPO_ROOT}` -- absolute path to the repository root
+- `{PLATFORMS}` -- comma-separated list of selected platform IDs
+- `{PLATFORM_FLUTTER_MD_CONTENTS}` -- full contents of `platform-flutter.md`
+
+## Prompt
+
+```
+You are building the Amplitude Flutter example app for E2E testing.
+Working directory: {REPO_ROOT}/example
+
+IMPORTANT: Cap your response to 3000 characters. Save build logs to
+/tmp/test-sdk-build-{platform}.log for each platform.
+
+Selected platforms: {PLATFORMS}
+
+For each platform, follow the build commands from the platform reference below.
+Key rules:
+- iOS SPM and iOS CocoaPods builds MUST be sequential (flutter config is global)
+- Run `flutter clean && flutter pub get` between iOS build variants
+- Android and Web builds can run alongside iOS
+- If a build fails, log the error and continue with remaining platforms
+
+{PLATFORM_FLUTTER_MD_CONTENTS}
+```
+
+## Expected Output
+
+```yaml
+build_status: pass | partial | fail
+platforms:
+  - id: ios-spm
+    status: pass | fail
+    artifact: "/path/to/Runner.app"
+    log: "/tmp/test-sdk-build-ios-spm.log"
+  - id: android
+    status: pass | fail
+    artifact: "/path/to/app-debug.apk"
+    log: "/tmp/test-sdk-build-android.log"
+```

--- a/.claude/skills/test-sdk/agents/build.md
+++ b/.claude/skills/test-sdk/agents/build.md
@@ -27,6 +27,10 @@ IMPORTANT: Cap your response to 3000 characters. Save build logs to
 
 Selected platforms: {PLATFORMS}
 
+All flutter build commands MUST include --dart-define-from-file=.env to inject
+the Amplitude API key at compile time. The .env file is in the working directory.
+Do NOT read, echo, or log the contents of the .env file.
+
 For each platform, follow the build commands from the platform reference below.
 Key rules:
 - iOS SPM and iOS CocoaPods builds MUST be sequential (flutter config is global)

--- a/.claude/skills/test-sdk/agents/cleanup.md
+++ b/.claude/skills/test-sdk/agents/cleanup.md
@@ -12,7 +12,7 @@ Task tool:
 
 ## Input Variables
 
-None.
+- `{PLATFORMS_TESTED}` -- comma-separated list of platforms that were tested
 
 ## Prompt
 
@@ -20,9 +20,14 @@ None.
 You are cleaning up after the Amplitude Flutter SDK E2E test.
 Cap your response to 1000 characters.
 
+Platforms tested: {PLATFORMS_TESTED}
+
 Tasks:
-1. Reset flutter config:
-   Shell: flutter config --no-enable-swift-package-manager
+1. Reset flutter config (ONLY if iOS was tested):
+   If {PLATFORMS_TESTED} contains "ios-spm" or "ios-cocoapods":
+     Shell: flutter config --no-enable-swift-package-manager
+   Otherwise: skip this step (flutter config is a global persistent setting
+   and should not be changed unless the test run modified it).
 
 2. Kill any background python HTTP servers on port 8080:
    Shell: lsof -ti:8080 | xargs kill -9 2>/dev/null || true
@@ -37,7 +42,7 @@ Tasks:
 cleanup_status: pass | partial
 tasks:
   - task: reset_flutter_config
-    status: pass | fail
+    status: pass | fail | skipped
   - task: kill_servers
     status: pass | fail
   - task: clean_logs

--- a/.claude/skills/test-sdk/agents/cleanup.md
+++ b/.claude/skills/test-sdk/agents/cleanup.md
@@ -1,6 +1,6 @@
 # Cleanup Subagent
 
-Reverts temporary changes and tears down test infrastructure.
+Tears down test infrastructure after E2E tests complete.
 
 ## Invocation
 
@@ -12,7 +12,7 @@ Task tool:
 
 ## Input Variables
 
-- `{API_KEY_PLACEHOLDER}` -- the placeholder string to restore (typically `API_KEY`)
+None.
 
 ## Prompt
 
@@ -21,17 +21,13 @@ You are cleaning up after the Amplitude Flutter SDK E2E test.
 Cap your response to 1000 characters.
 
 Tasks:
-1. Revert the API key in example/lib/main.dart:
-   Read the file, replace the current API key with '{API_KEY_PLACEHOLDER}' in
-   the MyApp() constructor call. Use StrReplace.
-
-2. Reset flutter config:
+1. Reset flutter config:
    Shell: flutter config --no-enable-swift-package-manager
 
-3. Kill any background python HTTP servers on port 8080:
+2. Kill any background python HTTP servers on port 8080:
    Shell: lsof -ti:8080 | xargs kill -9 2>/dev/null || true
 
-4. Clean up build logs:
+3. Clean up build logs:
    Shell: rm -rf /tmp/test-sdk-build-*.log
 ```
 
@@ -40,10 +36,10 @@ Tasks:
 ```yaml
 cleanup_status: pass | partial
 tasks:
-  - task: revert_api_key
-    status: pass | fail
   - task: reset_flutter_config
     status: pass | fail
   - task: kill_servers
+    status: pass | fail
+  - task: clean_logs
     status: pass | fail
 ```

--- a/.claude/skills/test-sdk/agents/cleanup.md
+++ b/.claude/skills/test-sdk/agents/cleanup.md
@@ -1,0 +1,49 @@
+# Cleanup Subagent
+
+Reverts temporary changes and tears down test infrastructure.
+
+## Invocation
+
+```
+Task tool:
+  subagent_type: "shell"
+  model: "fast"
+```
+
+## Input Variables
+
+- `{API_KEY_PLACEHOLDER}` -- the placeholder string to restore (typically `API_KEY`)
+
+## Prompt
+
+```
+You are cleaning up after the Amplitude Flutter SDK E2E test.
+Cap your response to 1000 characters.
+
+Tasks:
+1. Revert the API key in example/lib/main.dart:
+   Read the file, replace the current API key with '{API_KEY_PLACEHOLDER}' in
+   the MyApp() constructor call. Use StrReplace.
+
+2. Reset flutter config:
+   Shell: flutter config --no-enable-swift-package-manager
+
+3. Kill any background python HTTP servers on port 8080:
+   Shell: lsof -ti:8080 | xargs kill -9 2>/dev/null || true
+
+4. Clean up build logs:
+   Shell: rm -rf /tmp/test-sdk-build-*.log
+```
+
+## Expected Output
+
+```yaml
+cleanup_status: pass | partial
+tasks:
+  - task: revert_api_key
+    status: pass | fail
+  - task: reset_flutter_config
+    status: pass | fail
+  - task: kill_servers
+    status: pass | fail
+```

--- a/.claude/skills/test-sdk/agents/preflight.md
+++ b/.claude/skills/test-sdk/agents/preflight.md
@@ -1,0 +1,90 @@
+# Pre-flight Check Subagent
+
+Validates the environment before running E2E tests.
+
+## Invocation
+
+```
+Task tool:
+  subagent_type: "generalPurpose"
+  model: "fast"
+```
+
+## Input Variables
+
+- `{API_KEY}` -- expected API key from `amplitude-project.md`
+- `{EXPECTED_ORG}` -- expected Amplitude org name
+- `{EXPECTED_ORG_ID}` -- expected Amplitude org ID
+- `{TOKEN_CLEARING_INSTRUCTIONS}` -- steps to clear cached MCP tokens
+
+## Prompt
+
+```
+You are running pre-flight checks for the Amplitude Flutter SDK E2E test skill.
+Run each check and return a YAML summary. Cap your response to 3000 characters.
+
+Checks (run all, report pass/fail/warn for each):
+
+1. FLUTTER SDK
+   Run `flutter --version` via Shell. Fail if not found.
+
+2. MOBILE DEVICES
+   Call `mobile_list_available_devices` on MCP server `user-mobile-mcp`.
+   Fail if no iOS simulators or Android emulators are available.
+   Return the list of device IDs and names.
+
+3. AMPLITUDE MCP
+   Call `get_context` on MCP server `plugin-amplitude-amplitude`.
+   Expected org: {EXPECTED_ORG} (ID {EXPECTED_ORG_ID}).
+   If not authenticated or wrong org, FAIL and include these token-clearing
+   instructions in your response:
+   {TOKEN_CLEARING_INSTRUCTIONS}
+
+4. API KEY
+   Read `example/lib/main.dart`. Check line containing `MyApp(`.
+   - If it contains '{API_KEY}' (the real key): PASS
+   - If it contains 'API_KEY' (placeholder): WARN -- "API key is placeholder,
+     events won't reach Amplitude. Set it to {API_KEY} before testing."
+   - If it contains a different key: WARN -- "API key is {found_key}, expected
+     {API_KEY}. Events will go to a different project."
+
+5. GIT BRANCH
+   Run `git branch --show-current`. If on `main` or `master`: WARN.
+
+6. MCP SCHEMA SPOT-CHECK
+   Call `mobile_list_available_devices` and `get_context` -- if either tool
+   name is not found on the respective server, FAIL with
+   "MCP server missing expected tools -- server may have changed."
+```
+
+## Expected Output
+
+```yaml
+preflight_status: pass | fail
+checks:
+  - name: flutter_sdk
+    status: pass | fail
+    detail: "Flutter 3.x.x"
+  - name: mobile_devices
+    status: pass | fail
+    detail: "Found N devices: ..."
+    devices:
+      - id: "DEVICE_ID"
+        name: "iPhone 16 Pro"
+        platform: ios
+      - id: "DEVICE_ID"
+        name: "Pixel 8 API 34"
+        platform: android
+  - name: amplitude_mcp
+    status: pass | fail
+    detail: "Authenticated to {org_name}"
+  - name: api_key
+    status: pass | warn
+    detail: "..."
+  - name: git_branch
+    status: pass | warn
+    detail: "On branch feature/xyz"
+  - name: mcp_schema
+    status: pass | fail
+    detail: "All expected tools present"
+```

--- a/.claude/skills/test-sdk/agents/preflight.md
+++ b/.claude/skills/test-sdk/agents/preflight.md
@@ -13,7 +13,12 @@ Task tool:
 ## Input Variables
 
 - `{REPO_ROOT}` -- absolute path to the repository root
-- `{TOKEN_CLEARING_INSTRUCTIONS}` -- steps to clear cached MCP tokens
+- `{SKILL_ROOT}` -- absolute path to `.claude/skills/test-sdk`
+
+## Self-Read References
+
+Read these files before executing checks:
+- `{SKILL_ROOT}/amplitude-project.md` -- for token-clearing instructions
 
 ## Prompt
 
@@ -49,9 +54,9 @@ Checks (run all, report pass/fail/warn for each):
 5. AMPLITUDE MCP
    Call `get_context` on MCP server `plugin-amplitude-amplitude`.
    If config from check 4 is available, verify the org matches.
-   If not authenticated or wrong org, FAIL and include these token-clearing
-   instructions in your response:
-   {TOKEN_CLEARING_INSTRUCTIONS}
+   If not authenticated or wrong org, FAIL and include the token-clearing
+   instructions from the "Token Clearing Instructions" section of
+   `{SKILL_ROOT}/amplitude-project.md` in your response.
    If check 4 returned config_needed, skip org verification but still confirm
    the MCP is authenticated.
 

--- a/.claude/skills/test-sdk/agents/preflight.md
+++ b/.claude/skills/test-sdk/agents/preflight.md
@@ -12,9 +12,7 @@ Task tool:
 
 ## Input Variables
 
-- `{API_KEY}` -- expected API key from `amplitude-project.md`
-- `{EXPECTED_ORG}` -- expected Amplitude org name
-- `{EXPECTED_ORG_ID}` -- expected Amplitude org ID
+- `{REPO_ROOT}` -- absolute path to the repository root
 - `{TOKEN_CLEARING_INSTRUCTIONS}` -- steps to clear cached MCP tokens
 
 ## Prompt
@@ -33,25 +31,41 @@ Checks (run all, report pass/fail/warn for each):
    Fail if no iOS simulators or Android emulators are available.
    Return the list of device IDs and names.
 
-3. AMPLITUDE MCP
+3. AMPLITUDE API KEY (.env file)
+   Run via Shell:
+   grep -cq '^AMPLITUDE_API_KEY=[0-9a-f]\{32\}$' {REPO_ROOT}/example/.env
+   Do NOT read or echo the file contents.
+   - Exit 0: PASS
+   - File missing: FAIL -- "Create example/.env with AMPLITUDE_API_KEY=<your-32-char-hex-key>"
+   - Format invalid: FAIL -- "example/.env must contain exactly: AMPLITUDE_API_KEY=<32-char-lowercase-hex>"
+
+4. PROJECT CONFIG (amplitude-project.local.yaml)
+   Check if {REPO_ROOT}/example/amplitude-project.local.yaml exists.
+   - If missing: return config_needed: true (not a FAIL -- main agent handles
+     this interactively by asking the user for project ID, org name, org ID).
+   - If present: read it, extract project_id, org_name, org_id. Include these
+     values in your output under project_config.
+
+5. AMPLITUDE MCP
    Call `get_context` on MCP server `plugin-amplitude-amplitude`.
-   Expected org: {EXPECTED_ORG} (ID {EXPECTED_ORG_ID}).
+   If config from check 4 is available, verify the org matches.
    If not authenticated or wrong org, FAIL and include these token-clearing
    instructions in your response:
    {TOKEN_CLEARING_INSTRUCTIONS}
+   If check 4 returned config_needed, skip org verification but still confirm
+   the MCP is authenticated.
 
-4. API KEY
-   Read `example/lib/main.dart`. Check line containing `MyApp(`.
-   - If it contains '{API_KEY}' (the real key): PASS
-   - If it contains 'API_KEY' (placeholder): WARN -- "API key is placeholder,
-     events won't reach Amplitude. Set it to {API_KEY} before testing."
-   - If it contains a different key: WARN -- "API key is {found_key}, expected
-     {API_KEY}. Events will go to a different project."
+6. API KEY IN MAIN.DART
+   Read {REPO_ROOT}/example/lib/main.dart. Check for the pattern
+   String.fromEnvironment('AMPLITUDE_API_KEY'.
+   - If found: PASS
+   - If not found (hardcoded key or old pattern): WARN -- "main.dart should
+     use String.fromEnvironment('AMPLITUDE_API_KEY') for dart-define injection"
 
-5. GIT BRANCH
+7. GIT BRANCH
    Run `git branch --show-current`. If on `main` or `master`: WARN.
 
-6. MCP SCHEMA SPOT-CHECK
+8. MCP SCHEMA SPOT-CHECK
    Call `mobile_list_available_devices` and `get_context` -- if either tool
    name is not found on the respective server, FAIL with
    "MCP server missing expected tools -- server may have changed."
@@ -61,6 +75,7 @@ Checks (run all, report pass/fail/warn for each):
 
 ```yaml
 preflight_status: pass | fail
+config_needed: true | false
 checks:
   - name: flutter_sdk
     status: pass | fail
@@ -75,12 +90,21 @@ checks:
       - id: "DEVICE_ID"
         name: "Pixel 8 API 34"
         platform: android
+  - name: api_key_env
+    status: pass | fail
+    detail: "example/.env present and valid"
+  - name: project_config
+    status: pass | config_needed
+    detail: "..."
+    project_id: 697899
+    org_name: "My Org"
+    org_id: 255821
   - name: amplitude_mcp
     status: pass | fail
     detail: "Authenticated to {org_name}"
-  - name: api_key
+  - name: api_key_main_dart
     status: pass | warn
-    detail: "..."
+    detail: "Uses String.fromEnvironment"
   - name: git_branch
     status: pass | warn
     detail: "On branch feature/xyz"

--- a/.claude/skills/test-sdk/agents/test-mobile.md
+++ b/.claude/skills/test-sdk/agents/test-mobile.md
@@ -1,0 +1,81 @@
+# Mobile Test Subagent
+
+Executes a test flow on an iOS simulator or Android emulator via mobile MCP.
+
+## Invocation
+
+```
+Task tool:
+  subagent_type: "generalPurpose"
+  model: "fast"
+```
+
+Launch one instance per mobile platform. All instances run in parallel.
+
+## Input Variables
+
+- `{PLATFORM}` -- platform ID (e.g., `ios-spm`, `android`)
+- `{DEVICE_ID}` -- simulator/emulator device ID from pre-flight
+- `{ARTIFACT_PATH}` -- path to built app (.app or .apk)
+- `{APP_ID}` -- bundle ID or package name
+- `{TEST_FLOW_STEPS}` -- steps from the selected test flow in `test-flows.md`
+
+## Prompt
+
+```
+You are testing the Amplitude Flutter SDK on a mobile device.
+Cap your response to 3000 characters. Save screenshots to /tmp/test-sdk/.
+
+Platform: {PLATFORM}
+Device ID: {DEVICE_ID}
+App path: {ARTIFACT_PATH}
+Package/Bundle ID: {APP_ID}
+
+Test flow to execute:
+{TEST_FLOW_STEPS}
+
+Instructions:
+1. Install the app: CallMcpTool server="user-mobile-mcp" tool="mobile_install_app"
+   args: { appPath: "{ARTIFACT_PATH}", deviceId: "{DEVICE_ID}" }
+
+2. Launch the app: CallMcpTool server="user-mobile-mcp" tool="mobile_launch_app"
+   args: { packageName: "{APP_ID}", deviceId: "{DEVICE_ID}" }
+
+3. Wait 3 seconds for app to initialize, then take a screenshot.
+
+4. Handle native dialogs: If you see a system dialog (e.g., tracking
+   transparency, permissions), dismiss or accept it by tapping the
+   appropriate button. Use mobile_list_elements_on_screen to find the
+   dialog buttons.
+
+5. Execute each step in the test flow:
+   a. Use mobile_list_elements_on_screen to find the target element
+   b. Tap it using mobile_click_on_screen_at_coordinates
+   c. If the action fails, RETRY ONCE (take a fresh element list, re-locate,
+      tap again). If it fails a second time, mark step as failed and continue.
+   d. Take a screenshot after each step
+
+6. After all steps, take a final screenshot.
+```
+
+## Expected Output
+
+```yaml
+test_status: pass | partial | fail
+platform: "{PLATFORM}"
+device: "{DEVICE_ID}"
+steps:
+  - step: 1
+    action: "Tap 'Send Event'"
+    status: pass | fail
+    retried: false
+    screenshot: "/tmp/test-sdk/{PLATFORM}-step-1.png"
+  - step: 2
+    action: "Tap 'Flush Events'"
+    status: pass | fail
+    retried: true
+    screenshot: "/tmp/test-sdk/{PLATFORM}-step-2.png"
+expected_events:
+  - event_type: "Dart Click"
+    count: 1
+```

--- a/.claude/skills/test-sdk/agents/test-mobile.md
+++ b/.claude/skills/test-sdk/agents/test-mobile.md
@@ -18,7 +18,13 @@ Launch one instance per mobile platform. All instances run in parallel.
 - `{DEVICE_ID}` -- simulator/emulator device ID from pre-flight
 - `{ARTIFACT_PATH}` -- path to built app (.app or .apk)
 - `{APP_ID}` -- bundle ID or package name
-- `{TEST_FLOW_STEPS}` -- steps from the selected test flow in `test-flows.md`
+- `{TEST_FLOW_NAME}` -- name of the test flow to execute from test-flows.md
+- `{SKILL_ROOT}` -- absolute path to the skill directory
+
+## Self-Read References
+
+Read this file before testing:
+- `{SKILL_ROOT}/test-flows.md` -- find the flow matching `{TEST_FLOW_NAME}`
 
 ## Prompt
 
@@ -31,8 +37,8 @@ Device ID: {DEVICE_ID}
 App path: {ARTIFACT_PATH}
 Package/Bundle ID: {APP_ID}
 
-Test flow to execute:
-{TEST_FLOW_STEPS}
+Step 1: Read `{SKILL_ROOT}/test-flows.md` and find the test flow named
+`{TEST_FLOW_NAME}`. Extract its steps and expected events.
 
 Instructions:
 1. Install the app: CallMcpTool server="user-mobile-mcp" tool="mobile_install_app"
@@ -48,7 +54,7 @@ Instructions:
    appropriate button. Use mobile_list_elements_on_screen to find the
    dialog buttons.
 
-5. Execute each step in the test flow:
+5. Execute each step from the test flow:
    a. Use mobile_list_elements_on_screen to find the target element
    b. Tap it using mobile_click_on_screen_at_coordinates
    c. If the action fails, RETRY ONCE (take a fresh element list, re-locate,

--- a/.claude/skills/test-sdk/agents/test-web.md
+++ b/.claude/skills/test-sdk/agents/test-web.md
@@ -13,7 +13,13 @@ Task tool:
 ## Input Variables
 
 - `{REPO_ROOT}` -- absolute path to the repository root
-- `{TEST_FLOW_STEPS}` -- steps from the selected test flow in `test-flows.md`
+- `{TEST_FLOW_NAME}` -- name of the test flow to execute from test-flows.md
+- `{SKILL_ROOT}` -- absolute path to the skill directory
+
+## Self-Read References
+
+Read this file before testing:
+- `{SKILL_ROOT}/test-flows.md` -- find the flow matching `{TEST_FLOW_NAME}`
 
 ## Prompt
 
@@ -21,7 +27,10 @@ Task tool:
 You are testing the Amplitude Flutter SDK in a web browser.
 Cap your response to 3000 characters. Save screenshots to /tmp/test-sdk/.
 
-First, start the web server:
+Step 1: Read `{SKILL_ROOT}/test-flows.md` and find the test flow named
+`{TEST_FLOW_NAME}`. Extract its steps and expected events.
+
+Start the web server:
   Shell: cd {REPO_ROOT}/example/build/web && python3 -m http.server 8080
   (run in background with block_until_ms: 0)
 
@@ -29,17 +38,25 @@ Then interact via cursor-ide-browser MCP:
 
 1. Navigate: browser_navigate to http://localhost:8080
 2. Take a snapshot: browser_snapshot to get element refs
-3. Handle any browser popups/dialogs if present
+3. ACTIVATE SEMANTICS: Flutter Web renders to a canvas element, so widgets
+   are invisible to browser_snapshot by default. Find the element with
+   aria-label "Enable accessibility" in the snapshot and click it using
+   browser_click. Wait 2 seconds for the semantics DOM tree to populate.
+   Take a fresh browser_snapshot -- you should now see all Flutter widgets
+   (buttons, text fields, etc.) as flt-semantics elements with ARIA labels.
+   If the "Enable accessibility" button is not found, take a screenshot and
+   report the issue.
+4. Handle any browser popups/dialogs if present
 
-4. Execute each step in the test flow:
-   {TEST_FLOW_STEPS}
-   a. Use browser_snapshot to find the target element
+5. Execute each step from the test flow. IMPORTANT: use refs from the
+   post-semantics snapshot (step 3), not the initial snapshot (step 2).
+   a. Use browser_snapshot to find the target element by its ARIA label
    b. Click it using browser_click with the element ref
    c. If the action fails, RETRY ONCE (take a fresh snapshot, re-locate,
       click again). If it fails a second time, mark step as failed.
    d. Take a screenshot after each step (browser_take_screenshot)
 
-5. After all steps, kill the python server.
+6. After all steps, kill the python server.
 ```
 
 ## Expected Output

--- a/.claude/skills/test-sdk/agents/test-web.md
+++ b/.claude/skills/test-sdk/agents/test-web.md
@@ -1,0 +1,59 @@
+# Web Test Subagent
+
+Executes a test flow in a web browser via cursor-ide-browser MCP.
+
+## Invocation
+
+```
+Task tool:
+  subagent_type: "generalPurpose"
+  model: "fast"
+```
+
+## Input Variables
+
+- `{REPO_ROOT}` -- absolute path to the repository root
+- `{TEST_FLOW_STEPS}` -- steps from the selected test flow in `test-flows.md`
+
+## Prompt
+
+```
+You are testing the Amplitude Flutter SDK in a web browser.
+Cap your response to 3000 characters. Save screenshots to /tmp/test-sdk/.
+
+First, start the web server:
+  Shell: cd {REPO_ROOT}/example/build/web && python3 -m http.server 8080
+  (run in background with block_until_ms: 0)
+
+Then interact via cursor-ide-browser MCP:
+
+1. Navigate: browser_navigate to http://localhost:8080
+2. Take a snapshot: browser_snapshot to get element refs
+3. Handle any browser popups/dialogs if present
+
+4. Execute each step in the test flow:
+   {TEST_FLOW_STEPS}
+   a. Use browser_snapshot to find the target element
+   b. Click it using browser_click with the element ref
+   c. If the action fails, RETRY ONCE (take a fresh snapshot, re-locate,
+      click again). If it fails a second time, mark step as failed.
+   d. Take a screenshot after each step (browser_take_screenshot)
+
+5. After all steps, kill the python server.
+```
+
+## Expected Output
+
+```yaml
+test_status: pass | partial | fail
+platform: web
+steps:
+  - step: 1
+    action: "Click 'Send Event'"
+    status: pass | fail
+    retried: false
+    screenshot: "/tmp/test-sdk/web-step-1.png"
+expected_events:
+  - event_type: "Dart Click"
+    count: 1
+```

--- a/.claude/skills/test-sdk/agents/verify.md
+++ b/.claude/skills/test-sdk/agents/verify.md
@@ -1,0 +1,49 @@
+# Verification Subagent
+
+Checks that expected events arrived in Amplitude after the test run.
+
+## Invocation
+
+```
+Task tool:
+  subagent_type: "generalPurpose"
+  model: "fast"
+```
+
+## Input Variables
+
+- `{PROJECT_ID}` -- Amplitude project ID from `amplitude-project.md`
+- `{EXPECTED_EVENTS_YAML}` -- combined expected events from all test subagents
+
+## Prompt
+
+```
+You are verifying that Amplitude received the expected events from the
+E2E test run. Cap your response to 3000 characters.
+
+Project ID: {PROJECT_ID}
+Expected events (combined from all platforms):
+{EXPECTED_EVENTS_YAML}
+
+Instructions:
+1. Wait 30 seconds, then poll for events.
+2. Call `search` on MCP server `plugin-amplitude-amplitude` with
+   args: { query: "{event_type}", projectId: {PROJECT_ID} }
+   for each expected event type.
+3. If events not found, wait 30 more seconds and retry.
+4. Use exponential backoff: 30s, 60s, 120s. Give up after 5 minutes total.
+5. For each expected event type, record whether it was found and approximate
+   count.
+```
+
+## Expected Output
+
+```yaml
+verification_status: pass | partial | fail
+events:
+  - event_type: "Dart Click"
+    expected_count: 4
+    found: true
+    detail: "Found in search results"
+total_wait_seconds: 30
+```

--- a/.claude/skills/test-sdk/agents/verify.md
+++ b/.claude/skills/test-sdk/agents/verify.md
@@ -30,8 +30,8 @@ Instructions:
 2. Call `search` on MCP server `plugin-amplitude-amplitude` with
    args: { query: "{event_type}", projectId: {PROJECT_ID} }
    for each expected event type.
-3. If events not found, wait 30 more seconds and retry.
-4. Use exponential backoff: 30s, 60s, 120s. Give up after 5 minutes total.
+3. If events not found, retry with exponential backoff: wait 60s, then 120s.
+4. Give up after 5 minutes total (30s initial + 60s + 120s + final 90s attempt).
 5. For each expected event type, record whether it was found and approximate
    count.
 ```

--- a/.claude/skills/test-sdk/amplitude-project.md
+++ b/.claude/skills/test-sdk/amplitude-project.md
@@ -1,0 +1,78 @@
+# Amplitude Project Configuration
+
+Project-specific Amplitude settings for event verification. Swap this file to
+test against a different Amplitude project.
+
+## Project Details
+
+| Field          | Value                                     |
+|----------------|-------------------------------------------|
+| Project Name   | `<YOUR_PROJECT_NAME>`                     |
+| Project ID     | `<YOUR_PROJECT_ID>`                       |
+| API Key        | `<YOUR_API_KEY>`                          |
+| Expected Org   | `<YOUR_ORG_NAME>`                         |
+| Org ID         | `<YOUR_ORG_ID>`                           |
+
+> **Setup**: Copy this file to `amplitude-project.local.md`, fill in your
+> values, and add `amplitude-project.local.md` to `.gitignore`. The skill
+> will check for the `.local` variant first, falling back to this template.
+
+## MCP Server
+
+- **Server name**: `plugin-amplitude-amplitude`
+- **Auth tool**: `mcp_auth` (call if `get_context` fails)
+- **Verification tool**: `search` with `projectId: <YOUR_PROJECT_ID>`
+
+## Default Tracking
+
+The example app uses `DefaultTrackingOptions.all()`, which automatically sends:
+
+- `Application Installed` -- first launch
+- `Application Opened` -- every launch
+- `Application Updated` -- after version change
+- `Application Backgrounded` -- when app goes to background
+
+These events appear in Amplitude without any user interaction. They can be used
+as a baseline to confirm the SDK is initialized and sending data.
+
+## API Key Validation
+
+During pre-flight, check `example/lib/main.dart` for the API key:
+
+- **Pass**: Contains the real API key (matches `<YOUR_API_KEY>` from this file)
+- **Warn (placeholder)**: Contains `API_KEY` literal -- events will not reach
+  Amplitude. The agent should offer to set the real key.
+- **Warn (different key)**: Contains a different key -- events will go to a
+  different project. Alert the user but do not block.
+
+## Token Clearing Instructions
+
+If the Amplitude MCP authenticates to the wrong organization, the cached OAuth
+token needs to be cleared manually. This happens when the user has multiple
+Amplitude orgs and the MCP cached a token for the wrong one.
+
+### Steps to fix
+
+1. **Quit Cursor completely** (Cmd+Q, not just close window)
+
+2. **Delete the cached MCP token**:
+
+```bash
+sqlite3 ~/Library/Application\ Support/Cursor/User/globalStorage/state.vscdb \
+  "DELETE FROM ItemTable WHERE key LIKE '%amplitude%';"
+```
+
+3. **Open Cursor** and start a new chat
+
+4. **Before triggering `mcp_auth`**, log into the correct Amplitude org in
+   your browser at https://app.amplitude.com -- the org selector is in the
+   top-left dropdown. Select the org matching `<YOUR_ORG_NAME>`.
+
+5. **Trigger `mcp_auth`** by calling:
+
+```
+CallMcpTool server="plugin-amplitude-amplitude" toolName="mcp_auth"
+```
+
+6. **Verify** by calling `get_context` and checking that the org matches
+   `<YOUR_ORG_NAME>` (ID `<YOUR_ORG_ID>`).

--- a/.claude/skills/test-sdk/amplitude-project.md
+++ b/.claude/skills/test-sdk/amplitude-project.md
@@ -1,27 +1,39 @@
 # Amplitude Project Configuration
 
-Project-specific Amplitude settings for event verification. Swap this file to
-test against a different Amplitude project.
+Project-specific Amplitude settings for event verification. This file is a
+**template** -- the skill reads actual values from
+`example/amplitude-project.local.yaml` (gitignored).
 
 ## Project Details
 
-| Field          | Value                                     |
-|----------------|-------------------------------------------|
-| Project Name   | `<YOUR_PROJECT_NAME>`                     |
-| Project ID     | `<YOUR_PROJECT_ID>`                       |
-| API Key        | `<YOUR_API_KEY>`                          |
-| Expected Org   | `<YOUR_ORG_NAME>`                         |
-| Org ID         | `<YOUR_ORG_ID>`                           |
+Non-secret project identifiers. On first run, the skill asks for these values
+and creates `example/amplitude-project.local.yaml` automatically.
 
-> **Setup**: Copy this file to `amplitude-project.local.md`, fill in your
-> values, and add `amplitude-project.local.md` to `.gitignore`. The skill
-> will check for the `.local` variant first, falling back to this template.
+Expected YAML format:
+
+```yaml
+project_id: 697899
+project_name: "My Test Project"
+org_name: "My Org"
+org_id: 255821
+```
+
+## API Key
+
+The API key lives in `example/.env` (gitignored, never read by the agent).
+It is injected at compile time via `--dart-define-from-file=.env`.
+
+Expected format:
+
+```
+AMPLITUDE_API_KEY=<32-char-hex-key>
+```
 
 ## MCP Server
 
 - **Server name**: `plugin-amplitude-amplitude`
 - **Auth tool**: `mcp_auth` (call if `get_context` fails)
-- **Verification tool**: `search` with `projectId: <YOUR_PROJECT_ID>`
+- **Verification tool**: `search` with `projectId` from local YAML
 
 ## Default Tracking
 
@@ -34,16 +46,6 @@ The example app uses `DefaultTrackingOptions.all()`, which automatically sends:
 
 These events appear in Amplitude without any user interaction. They can be used
 as a baseline to confirm the SDK is initialized and sending data.
-
-## API Key Validation
-
-During pre-flight, check `example/lib/main.dart` for the API key:
-
-- **Pass**: Contains the real API key (matches `<YOUR_API_KEY>` from this file)
-- **Warn (placeholder)**: Contains `API_KEY` literal -- events will not reach
-  Amplitude. The agent should offer to set the real key.
-- **Warn (different key)**: Contains a different key -- events will go to a
-  different project. Alert the user but do not block.
 
 ## Token Clearing Instructions
 
@@ -66,7 +68,7 @@ sqlite3 ~/Library/Application\ Support/Cursor/User/globalStorage/state.vscdb \
 
 4. **Before triggering `mcp_auth`**, log into the correct Amplitude org in
    your browser at https://app.amplitude.com -- the org selector is in the
-   top-left dropdown. Select the org matching `<YOUR_ORG_NAME>`.
+   top-left dropdown. Select the org matching your expected org.
 
 5. **Trigger `mcp_auth`** by calling:
 
@@ -75,4 +77,4 @@ CallMcpTool server="plugin-amplitude-amplitude" toolName="mcp_auth"
 ```
 
 6. **Verify** by calling `get_context` and checking that the org matches
-   `<YOUR_ORG_NAME>` (ID `<YOUR_ORG_ID>`).
+   the expected org name and ID from your local YAML.

--- a/.claude/skills/test-sdk/examples.md
+++ b/.claude/skills/test-sdk/examples.md
@@ -1,0 +1,101 @@
+# Usage Examples
+
+How to invoke the test-sdk skill in different scenarios.
+
+## Default Smoke Test
+
+> User: "Test the SDK on all platforms"
+
+The agent:
+1. Reads SKILL.md, detects test-sdk skill match
+2. Runs pre-flight (subagent checks Flutter, devices, Amplitude MCP, API key)
+3. Asks: "Default smoke test or customize?" -- user picks default
+4. Builds iOS SPM, iOS CocoaPods, Android, Web (subagent)
+5. Launches 4 parallel test subagents with the basic-event flow
+6. Verifies "Dart Click" events in Amplitude (subagent)
+7. Cleans up (reverts API key, resets config)
+8. Presents results table
+
+Total user interaction: 1 question (default vs customize).
+
+## iOS-Only Quick Test
+
+> User: "Quick smoke test on iOS SPM only"
+
+The agent:
+1. Reads SKILL.md
+2. Runs pre-flight
+3. Asks: "Default or customize?" -- user picks customize
+4. Asks: "Which platforms?" -- user selects only "iOS (Swift Package Manager)"
+5. Asks: "Which test flow?" -- user picks basic-event
+6. Builds iOS SPM only
+7. Runs test on one simulator
+8. Verifies events
+9. Cleans up
+
+## Full Smoke Test
+
+> User: "Run the full smoke test on Android"
+
+The agent:
+1. Reads SKILL.md
+2. Runs pre-flight
+3. Asks: "Default or customize?" -- user picks customize
+4. Asks: "Which platforms?" -- user selects only "Android"
+5. Asks: "Which test flow?" -- user picks full-smoke
+6. Builds Android APK
+7. Runs all flows (basic-event, identify, revenue, set-group) on emulator
+8. Verifies all expected events in Amplitude
+9. Cleans up
+
+## Testing a New Feature
+
+> User: "I added a new setOptOut method, test it on iOS and Android"
+
+The agent:
+1. Reads SKILL.md
+2. Runs pre-flight
+3. Asks: "Default or customize?" -- user picks customize
+4. Asks: "Which platforms?" -- user selects iOS SPM + Android
+5. Asks: "Which test flow?" -- user picks "Custom -- I'll describe what to test"
+6. Agent asks: "Describe the test and whether the example app needs changes"
+7. User: "Tap 'Opt Out', send an event, flush, then verify no events arrive.
+   Then tap 'Opt In', send an event, flush, verify events arrive. The buttons
+   are already in the example app."
+8. Agent builds and tests with the custom flow
+9. Verifies events in Amplitude
+
+## Pre-flight Failure Example
+
+> User: "Test the SDK"
+
+Pre-flight subagent returns:
+
+```yaml
+preflight_status: fail
+checks:
+  - name: amplitude_mcp
+    status: fail
+    detail: "Authenticated to wrong org"
+```
+
+The agent stops and reports:
+
+> Pre-flight failed: Amplitude MCP is authenticated to the wrong organization.
+> Follow the token clearing instructions in `amplitude-project.md` to fix.
+
+## Partial Build Failure Example
+
+If iOS CocoaPods build fails but iOS SPM and Android succeed:
+
+```
+## E2E Test Results
+
+| Platform      | Build  | Test   | Events Verified |
+|---------------|--------|--------|-----------------|
+| iOS SPM       | pass   | pass   | yes             |
+| iOS CocoaPods | FAIL   | skip   | skip            |
+| Android       | pass   | pass   | yes             |
+
+Build log: /tmp/test-sdk-build-ios-cocoapods.log
+```

--- a/.claude/skills/test-sdk/platform-flutter.md
+++ b/.claude/skills/test-sdk/platform-flutter.md
@@ -16,8 +16,8 @@ skill to a different platform (React Native, Swift, Kotlin, etc.).
 ## Project Structure
 
 - **Example app root**: `example/`
-- **API key location**: `example/lib/main.dart`, line containing `MyApp(`
-- **API key pattern**: `void main() => runApp(const MyApp('API_KEY'));`
+- **API key source**: `example/.env` (injected via `--dart-define-from-file`)
+- **API key in code**: `example/lib/main.dart` uses `String.fromEnvironment('AMPLITUDE_API_KEY')`
 - **Plugin source (Darwin)**: `darwin/`
 - **Plugin source (Android)**: `android/`
 
@@ -31,7 +31,7 @@ All commands run from the `example/` directory unless noted otherwise.
 flutter config --enable-swift-package-manager
 flutter clean
 flutter pub get
-flutter build ios --debug --simulator --no-codesign 2>&1 | tee /tmp/test-sdk-build-ios-spm.log
+flutter build ios --debug --simulator --no-codesign --dart-define-from-file=.env 2>&1 | tee /tmp/test-sdk-build-ios-spm.log
 ```
 
 ### ios-cocoapods
@@ -41,19 +41,19 @@ flutter config --no-enable-swift-package-manager
 flutter clean
 flutter pub get
 cd ios && pod repo update && cd ..
-flutter build ios --debug --simulator --no-codesign 2>&1 | tee /tmp/test-sdk-build-ios-cocoapods.log
+flutter build ios --debug --simulator --no-codesign --dart-define-from-file=.env 2>&1 | tee /tmp/test-sdk-build-ios-cocoapods.log
 ```
 
 ### android
 
 ```bash
-flutter build apk --debug 2>&1 | tee /tmp/test-sdk-build-android.log
+flutter build apk --debug --dart-define-from-file=.env 2>&1 | tee /tmp/test-sdk-build-android.log
 ```
 
 ### web
 
 ```bash
-flutter build web --debug 2>&1 | tee /tmp/test-sdk-build-web.log
+flutter build web --dart-define-from-file=.env 2>&1 | tee /tmp/test-sdk-build-web.log
 ```
 
 To serve after build:

--- a/.claude/skills/test-sdk/platform-flutter.md
+++ b/.claude/skills/test-sdk/platform-flutter.md
@@ -1,0 +1,121 @@
+# Platform Reference: Flutter
+
+Platform-specific build commands, paths, app identifiers, and known issues for
+the Amplitude Flutter SDK example app. Swap this file to adapt the test-sdk
+skill to a different platform (React Native, Swift, Kotlin, etc.).
+
+## Supported Platforms
+
+| Platform ID     | Description                        |
+|-----------------|------------------------------------|
+| `ios-spm`       | iOS via Swift Package Manager      |
+| `ios-cocoapods` | iOS via CocoaPods                  |
+| `android`       | Android (APK)                      |
+| `web`           | Flutter Web (served via HTTP)      |
+
+## Project Structure
+
+- **Example app root**: `example/`
+- **API key location**: `example/lib/main.dart`, line containing `MyApp(`
+- **API key pattern**: `void main() => runApp(const MyApp('API_KEY'));`
+- **Plugin source (Darwin)**: `darwin/`
+- **Plugin source (Android)**: `android/`
+
+## Build Commands
+
+All commands run from the `example/` directory unless noted otherwise.
+
+### ios-spm
+
+```bash
+flutter config --enable-swift-package-manager
+flutter clean
+flutter pub get
+flutter build ios --debug --simulator --no-codesign 2>&1 | tee /tmp/test-sdk-build-ios-spm.log
+```
+
+### ios-cocoapods
+
+```bash
+flutter config --no-enable-swift-package-manager
+flutter clean
+flutter pub get
+cd ios && pod repo update && cd ..
+flutter build ios --debug --simulator --no-codesign 2>&1 | tee /tmp/test-sdk-build-ios-cocoapods.log
+```
+
+### android
+
+```bash
+flutter build apk --debug 2>&1 | tee /tmp/test-sdk-build-android.log
+```
+
+### web
+
+```bash
+flutter build web --debug 2>&1 | tee /tmp/test-sdk-build-web.log
+```
+
+To serve after build:
+
+```bash
+cd build/web && python3 -m http.server 8080
+```
+
+## Build Sequencing
+
+- **iOS SPM and iOS CocoaPods MUST be sequential** -- `flutter config` is a
+  global setting, so switching between SPM and CocoaPods requires a clean build.
+- Run `flutter clean && flutter pub get` between iOS build variants.
+- Android and Web builds are independent and can run in parallel with iOS.
+- Recommended order: ios-spm -> ios-cocoapods -> android (parallel) + web (parallel).
+
+## Build Output Paths
+
+| Platform        | Artifact Path (relative to `example/`)           |
+|-----------------|--------------------------------------------------|
+| `ios-spm`       | `build/ios/iphonesimulator/Runner.app`           |
+| `ios-cocoapods` | `build/ios/iphonesimulator/Runner.app`           |
+| `android`       | `build/app/outputs/flutter-apk/app-debug.apk`   |
+| `web`           | `build/web/`                                     |
+
+Note: Both iOS variants produce the same artifact path. Copy the artifact to
+`/tmp/test-sdk-ios-spm-Runner.app` or `/tmp/test-sdk-ios-cocoapods-Runner.app`
+after each build to avoid overwriting.
+
+## App Identifiers
+
+| Platform | Identifier                                    |
+|----------|-----------------------------------------------|
+| iOS      | `com.amplitude.flutterExample` (bundle ID)    |
+| Android  | `com.amplitude.amplitude_flutter_example`     |
+| Web      | `http://localhost:8080`                        |
+
+## Known Issues
+
+### Flutter.xcframework symlink
+
+Some machines have Flutter SDK installed at a non-standard path. The Xcode
+project may reference `Flutter.xcframework` via a hardcoded relative path. If
+the iOS build fails with "There is no XCFramework found at ...", create a
+symlink:
+
+```bash
+ln -sf /path/to/your/flutter /Users/$USER/code/flutter
+```
+
+### Gradle Kotlin version warning
+
+Android builds may show a Kotlin version compatibility warning. This is
+**non-blocking** -- the build still succeeds.
+
+### CocoaPods spec repo
+
+If the CocoaPods build fails with "CocoaPods could not find compatible
+versions", run `pod repo update` in the `example/ios/` directory. This is
+already included in the build commands above.
+
+### iOS simulator selection
+
+When multiple iOS simulators are available, prefer one that is already booted.
+If none are booted, use the latest iPhone model available.

--- a/.claude/skills/test-sdk/test-flows.md
+++ b/.claude/skills/test-sdk/test-flows.md
@@ -1,0 +1,190 @@
+# Test Flows
+
+Reusable test scenarios for the Amplitude Flutter SDK example app. Each flow
+defines the UI interactions to perform and the expected Amplitude events.
+
+## Flow Format
+
+Each flow is a structured block with:
+
+- **id**: Short identifier used in SKILL.md
+- **description**: What the flow tests
+- **preconditions**: App state required before starting
+- **steps**: Ordered list of UI actions
+- **expected_events**: Amplitude event types that should appear after flush
+
+## Locator Strategy
+
+For mobile (user-mobile-mcp):
+1. Call `mobile_list_elements_on_screen` to get element list
+2. Find the target element by its text label
+3. Use `mobile_click_on_screen_at_coordinates` with the element's coordinates
+4. If the element is not visible, use `mobile_swipe_on_screen` to scroll down,
+   then re-list elements
+
+For web (cursor-ide-browser):
+1. Call `browser_snapshot` to get element refs
+2. Find the target element by its text content
+3. Click using `browser_click` with the ref
+
+## Scrolling
+
+The example app is a long scrollable list. Elements near the bottom (Revenue,
+Group, Opt Out/In, Flush Events) may require scrolling. The app layout top to
+bottom:
+
+1. Device ID form
+2. User ID form
+3. Reset button
+4. Session ID display
+5. Event form ("Send Event" button)
+6. Identify form ("Send Identify" button)
+7. Group form ("Set Group" button)
+8. Group Identify form ("Send Group Identify" button)
+9. Revenue form ("Send Revenue" button)
+10. Opt Out / Opt In buttons
+11. "Flush Events" button
+12. Status message text
+
+---
+
+## basic-event
+
+**Description**: Send the default "Dart Click" event and flush.
+
+**Preconditions**: App is launched and initialized (status shows "Amplitude
+initialized").
+
+**Steps**:
+
+| Step | Action                  | Target Element      | Expected Status Message |
+|------|-------------------------|---------------------|-------------------------|
+| 1    | Tap button              | "Send Event"        | "Event sent."           |
+| 2    | Scroll down if needed   | --                  | --                      |
+| 3    | Tap button              | "Flush Events"      | "Events flushed."       |
+
+**Expected Events**:
+
+```yaml
+- event_type: "Dart Click"
+  count: 1
+```
+
+**Notes**: The event name text field defaults to "Dart Click". No need to type
+anything -- just tap "Send Event".
+
+---
+
+## identify
+
+**Description**: Send an identify call with user properties and flush.
+
+**Preconditions**: App is launched and initialized.
+
+**Steps**:
+
+| Step | Action                  | Target Element          | Expected Status Message |
+|------|-------------------------|-------------------------|-------------------------|
+| 1    | Scroll to Identify form | --                      | --                      |
+| 2    | Tap button              | "Send Identify"         | "Identify sent."        |
+| 3    | Scroll down if needed   | --                      | --                      |
+| 4    | Tap button              | "Flush Events"          | "Events flushed."       |
+
+**Expected Events**:
+
+```yaml
+- event_type: "$identify"
+  count: 1
+```
+
+**Notes**: The identify form has optional key/value fields for custom user
+properties. For the basic flow, skip filling them -- the form sends a default
+`identify_test` property with a timestamp. If the test flow specifies custom
+properties, type into "User Property Key" and "User Property Value" fields
+before tapping "Send Identify".
+
+---
+
+## revenue
+
+**Description**: Send a revenue event and flush.
+
+**Preconditions**: App is launched and initialized.
+
+**Steps**:
+
+| Step | Action                  | Target Element          | Expected Status Message |
+|------|-------------------------|-------------------------|-------------------------|
+| 1    | Scroll to Revenue form  | --                      | --                      |
+| 2    | Tap button              | "Send Revenue"          | "Revenue sent."         |
+| 3    | Scroll down if needed   | --                      | --                      |
+| 4    | Tap button              | "Flush Events"          | "Events flushed."       |
+
+**Expected Events**:
+
+```yaml
+- event_type: "revenue_amount"
+  count: 1
+```
+
+**Notes**: The revenue form has fields for product ID, quantity, and price.
+The defaults are sufficient for a smoke test.
+
+---
+
+## set-group
+
+**Description**: Set group membership and flush.
+
+**Preconditions**: App is launched and initialized.
+
+**Steps**:
+
+| Step | Action                  | Target Element          | Expected Status Message |
+|------|-------------------------|-------------------------|-------------------------|
+| 1    | Scroll to Group form    | --                      | --                      |
+| 2    | Tap button              | "Set Group"             | "Group set."            |
+| 3    | Scroll down if needed   | --                      | --                      |
+| 4    | Tap button              | "Flush Events"          | "Events flushed."       |
+
+**Expected Events**:
+
+```yaml
+- event_type: "$identify"
+  count: 1
+```
+
+**Notes**: Setting a group triggers an `$identify` event with group properties.
+The group form has fields for group type and group name with defaults.
+
+---
+
+## full-smoke
+
+**Description**: Run all flows sequentially on a single app session.
+
+**Preconditions**: App is launched and initialized.
+
+**Steps**: Execute the following flows in order, without restarting the app:
+
+1. `basic-event`
+2. `identify`
+3. `revenue`
+4. `set-group`
+5. Final flush (tap "Flush Events" once more at the end)
+
+**Expected Events** (combined):
+
+```yaml
+- event_type: "Dart Click"
+  count: 1
+- event_type: "$identify"
+  count: 2
+- event_type: "revenue_amount"
+  count: 1
+```
+
+**Notes**: The `$identify` count is 2 because both the `identify` flow and the
+`set-group` flow produce `$identify` events. The final flush ensures all
+remaining events are sent. Some events may have been flushed in intermediate
+steps already.

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ example/pubspec.lock
 example/ios/Podfile.lock
 
 coverage/
+
+# test-sdk skill local config
+example/.env
+example/amplitude-project.local.yaml

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -2,4 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'my_app.dart';
 
-void main() => runApp(const MyApp('API_KEY'));
+void main() => runApp(
+      const MyApp(
+        String.fromEnvironment('AMPLITUDE_API_KEY', defaultValue: 'API_KEY'),
+      ),
+    );


### PR DESCRIPTION
## Summary

- Adds a SKILL.md-based agent skill at `.claude/skills/test-sdk/` that orchestrates end-to-end smoke testing of the Amplitude Flutter SDK across iOS (SPM + CocoaPods), Android, and Web platforms.
- Uses the [SKILL.md open standard](https://www.mdskills.ai/specs/skill-md) for cross-platform compatibility (Cursor, Claude Code, Codex). Placed in `.claude/skills/` so both Cursor and Claude Code auto-discover it.
- Delegates all heavy work (pre-flight checks, builds, device testing, event verification, cleanup) to `fast` subagents to minimize main agent context usage.

### Files

| File | Purpose |
|------|---------|
| `SKILL.md` | Thin orchestrator: 6 phases (pre-flight, planning, build, test, verify, cleanup), error handling, design rationale |
| `platform-flutter.md` | Flutter-specific build commands, paths, app IDs, known issues (swappable for other platforms) |
| `amplitude-project.md` | Amplitude project config template with placeholders for local setup |
| `test-flows.md` | 5 reusable test scenarios: basic-event, identify, revenue, set-group, full-smoke |
| `examples.md` | Usage examples showing default, custom, and failure scenarios |

### Design rationale

This is a **lightweight, agent-native smoke check** -- no external test runner dependencies (no Appium, no WDIO, no Node). It complements the CI-grade E2E harness for interactive pre-PR validation.

## Test plan

- [ ] In Cursor or Claude Code, invoke `/test-sdk` or say "test the SDK" -- verify the skill is auto-discovered
- [ ] Run the default smoke test flow on at least one platform (e.g., iOS SPM)
- [ ] Verify pre-flight correctly detects: missing API key, wrong Amplitude org, no simulators
- [ ] Verify events appear in the configured Amplitude project after test run