### PR TITLE
chore: SECENG-7706 [security] Pin versions of GitHub Actions to full commit hash (fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ${{ github.actor }} permission check to do a release
-        uses: "lannonbr/repo-permission-check-action@2.0.2"
+        uses: "lannonbr/repo-permission-check-action@2bb8c89ba8bf115c4bfab344d6a6f442b24c9a1f" # 2.0.2
         with:
           permission: "write"
         env:


### PR DESCRIPTION
This PR pins versions of GitHub Actions to full commit hash via automated scripts.
This PR fixes issues with previous script versions which skipped actions wrapped in "" quotation marks.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

Please merge this pull request by 2026-04-10.

For any questions, please ask in the Slack channel #help-security.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a GitHub Actions dependency pin intended to be behavior-preserving, with only a small chance of breaking if the pinned commit differs from the tag or is removed.
> 
> **Overview**
> Updates `.github/workflows/release.yml` to pin `lannonbr/repo-permission-check-action` from the `2.0.2` tag to the corresponding full commit SHA, improving supply-chain integrity without intended workflow behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c9a9ce54c7367bf3ccab813c06c0a4b0e4bffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->