### PR TITLE
fix(android): bump analytics-android pin to 1.29.x for session-replay compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,10 +47,14 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-reflect:1.6.10"
     implementation "androidx.annotation:annotation:1.7.0"
 
-    // Locked to specific minor version to prevent binary compatibility issues.
-    // Allowing newer minor versions previously caused NoSuchMethodError due to
-    // compile-time vs runtime version mismatches (see #283).
-    implementation 'com.amplitude:analytics-android:1.27.+'
+    // Pinned to the 1.29.x line for binary compatibility. amplitude_session_replay's
+    // session-replay-android (>= 0.26.4) requires the shared transitive
+    // com.amplitude:analytics-core in [1.29.0, 2.0.0); older analytics-android (1.27.x)
+    // was compiled against the enum RemoteConfigClient.Key and crashes with
+    // NoSuchFieldError (ANALYTICS_SDK) once core resolves to 1.29.x (see #307).
+    // Staying within a single minor line avoids the compile-time vs runtime mismatch
+    // that previously caused NoSuchMethodError on newer minors (see #283).
+    implementation 'com.amplitude:analytics-android:1.29.+'
     testImplementation 'org.mockito:mockito-core:4.0.0'
     testImplementation "io.mockk:mockk:1.12.4"
     testImplementation "io.mockk:mockk-agent-jvm:1.11.0"


### PR DESCRIPTION
## Summary

Using `amplitude_flutter` together with `amplitude_session_replay` in the same Android app crashes on launch with:

```
java.lang.NoSuchFieldError: No field ANALYTICS_SDK of type
  Lcom/amplitude/core/remoteconfig/RemoteConfigClient$Key; ...
  at com.amplitude.android.AutocaptureManager.<init>(AutocaptureManager.kt:44)
  at com.amplitude.android.Timeline.startNewSession(Timeline.kt:164)
```

Fixes #307.

## Root cause

`amplitude_flutter` pinned `com.amplitude:analytics-android:1.27.+`. `analytics-android` and `analytics-core` are separate artifacts, and `analytics-core` is a **shared transitive** dependency of both plugins:

- `analytics-android:1.27.0` requests `analytics-core:1.27.0` (soft/preferred), compiled against the **enum** `RemoteConfigClient.Key` (which had the static field `ANALYTICS_SDK`).
- `session-replay-android` (≥ 0.26.4) requires `analytics-core:[1.29.0,2.0.0)`.

Gradle's highest-version-wins resolution therefore forces `analytics-core` to **1.29.x**, where [amplitude/Amplitude-Kotlin#409](https://github.com/amplitude/Amplitude-Kotlin/pull/409) converted `Key` from an `enum class` to a `sealed class`, removing the static `ANALYTICS_SDK` field. `analytics-android` stays frozen at 1.27.0, so its `AutocaptureManager` bytecode does a `getstatic` on the now-missing field → `NoSuchFieldError` at startup (autocapture runs during session start).

This does not reproduce with `amplitude_flutter` alone — it only surfaces once `amplitude_session_replay` drags `analytics-core` forward.

## Fix

Bump the pin so `analytics-android` moves in lockstep with the sealed-class core:

```diff
- implementation 'com.amplitude:analytics-android:1.27.+'
+ implementation 'com.amplitude:analytics-android:1.29.+'
```

Both plugins now reference the same 1.29.x `Key` model. The plugin already builds its `Configuration` via `ConfigurationBuilder(...).build()` (stable public API), which avoids the synthetic-constructor fragility behind the original 1.27 pin (#283).

## Verification

Reproduced and fixed on an Android emulator with an example app combining **both** plugins (`amplitude_session_replay 0.1.0-beta.3`):

| | `1.27.+` (before) | `1.29.+` (after) |
|---|---|---|
| Resolved `analytics-android` | 1.27.0 | 1.29.1 |
| Resolved `analytics-core` | 1.29.1 (dragged up by SR) | 1.29.1 |
| Launch | ❌ `NoSuchFieldError`, process dies | ✅ launches, Amplitude inits, logs `[Amplitude] Application Opened` |

After the bump, logcat is clean (no `NoSuchFieldError`/FATAL) and all three of `analytics-android`, its transitive `analytics-core`, and session-replay's `analytics-core` resolve to `1.29.1`.

## Follow-ups (not in this PR)

- Publish a documented compatibility matrix between `amplitude_flutter` and `amplitude_session_replay`.
- Consider an exact pin (e.g. `1.29.1`) over the `1.29.+` range if stricter reproducibility is desired (per #283's guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the resolved Amplitude Android SDK minor line for all consumers; low code churn but affects runtime analytics initialization and compatibility with session replay.
> 
> **Overview**
> **Bumps the Android dependency pin** from `com.amplitude:analytics-android:1.27.+` to `1.29.+` so it stays aligned with the `analytics-core` version that `amplitude_session_replay` pulls in (≥ 1.29.0).
> 
> When both Flutter plugins are used together, Gradle can resolve `analytics-core` to 1.29.x while `analytics-android` stayed on 1.27.x, which caused a startup **`NoSuchFieldError`** on `RemoteConfigClient.Key.ANALYTICS_SDK` after core moved from an enum to a sealed class. The updated comments document that constraint and the earlier #283 minor-line pinning rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032b855b01d3067af4246026421063474581a2f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->