### PR TITLE
fix(android): return device ID only after native SDK build completes

### DIFF
--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -2,6 +2,8 @@ package com.amplitude.amplitude_flutter
 
 import android.app.Activity
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.RestrictTo
 import com.amplitude.android.Amplitude
 import com.amplitude.android.AutocaptureOption
@@ -34,6 +36,8 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private var appOpenedTracked = false
 
     private lateinit var channel: MethodChannel
+
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     companion object {
         private const val methodChannelName = "amplitude_flutter"
@@ -141,10 +145,23 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             }
 
             "getDeviceId" -> {
-                val deviceId = amplitude.getDeviceId()
-                amplitude.logger.debug("Get deviceId: $deviceId")
-
-                result.success(deviceId)
+                // The native SDK assigns the device ID on a background coroutine
+                // (amplitude.isBuilt). Reading getDeviceId() before that completes
+                // returns null, so wait for the build to finish before replying.
+                // getDeviceId() is nullable by contract, so a failed build resolves
+                // to null rather than surfacing a PlatformException to Dart callers.
+                amplitude.isBuilt.invokeOnCompletion { exception ->
+                    mainHandler.post {
+                        if (exception != null) {
+                            amplitude.logger.warn("getDeviceId: Amplitude build did not complete: ${exception.message}")
+                            result.success(null)
+                        } else {
+                            val deviceId = amplitude.getDeviceId()
+                            amplitude.logger.debug("Get deviceId: $deviceId")
+                            result.success(deviceId)
+                        }
+                    }
+                }
             }
 
             "setDeviceId" -> {

--- a/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPlugin.kt
@@ -173,10 +173,24 @@ class AmplitudeFlutterPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
             }
 
             "getSessionId" -> {
-                val sessionId = amplitude.sessionId
-                amplitude.logger.debug("Get sessionId: $sessionId")
-
-                result.success(sessionId)
+                // Like the device ID, the session ID is restored from storage on
+                // the native build coroutine (amplitude.isBuilt): before it
+                // completes, amplitude.sessionId returns the -1 sentinel. Wait for
+                // the build so callers get the restored session ID rather than -1.
+                // (On a brand-new install the value may still be -1 until the first
+                // session starts, which is expected.)
+                amplitude.isBuilt.invokeOnCompletion { exception ->
+                    mainHandler.post {
+                        if (exception != null) {
+                            amplitude.logger.warn("getSessionId: Amplitude build did not complete: ${exception.message}")
+                            result.success(null)
+                        } else {
+                            val sessionId = amplitude.sessionId
+                            amplitude.logger.debug("Get sessionId: $sessionId")
+                            result.success(sessionId)
+                        }
+                    }
+                }
             }
 
             "setOptOut" -> {

--- a/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt
@@ -173,6 +173,23 @@ class AmplitudeFlutterPluginTest {
     }
 
     @Test
+    fun getSessionIdReturnsValueAfterInit() {
+        plugin.onMethodCall(MethodCall("init", JSONObject(testConfigurationMap)), result)
+        awaitInitialized()
+
+        val sessionIdResult = spyk<MethodChannel.Result>()
+        plugin.onMethodCall(
+            MethodCall("getSessionId", JSONObject(mapOf("instanceName" to "\$default_instance"))),
+            sessionIdResult
+        )
+        awaitInitialized()
+        // The reply is delivered (not left pending) with a non-null session ID
+        // once the native build completes. The concrete value may be the -1
+        // sentinel on a brand-new install until a session starts.
+        verify(exactly = 1) { sessionIdResult.success(any<Long>()) }
+    }
+
+    @Test
     fun shouldTrack() {
         val initMethodCall = MethodCall("init", JSONObject(testConfigurationMap))
         plugin.onMethodCall(initMethodCall, result)

--- a/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt
@@ -1,6 +1,7 @@
 package com.amplitude.amplitude_flutter
 
 import android.content.Context
+import android.os.Looper
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -8,11 +9,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
+import kotlinx.coroutines.runBlocking
 import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 
 @Config(manifest=Config.NONE)
@@ -141,12 +144,32 @@ class AmplitudeFlutterPluginTest {
         plugin.onAttachedToEngine(binding)
     }
 
+    private fun awaitInitialized() {
+        val amp = AmplitudeFlutterPlugin.getAmplitudeInstanceById("\$default_instance")!!
+        runBlocking { amp.isBuilt.await() }
+        shadowOf(Looper.getMainLooper()).idle()
+    }
+
     @Test
     fun shouldInit() {
         val methodCall = MethodCall("init", JSONObject(testConfigurationMap))
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("init called..") }
+    }
+
+    @Test
+    fun getDeviceIdReturnsNonNullAfterInit() {
+        plugin.onMethodCall(MethodCall("init", JSONObject(testConfigurationMap)), result)
+        awaitInitialized()
+
+        val deviceIdResult = spyk<MethodChannel.Result>()
+        plugin.onMethodCall(
+            MethodCall("getDeviceId", JSONObject(mapOf("instanceName" to "\$default_instance"))),
+            deviceIdResult
+        )
+        awaitInitialized()
+        verify(exactly = 1) { deviceIdResult.success(match<String> { it.isNotEmpty() }) }
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes a first-launch race on **Android** where `await amplitude.getDeviceId()` (and `getSessionId()`) can return `null` / `-1` even after the app has awaited `isBuilt`. In the reported case this broke device-ID-based attribution — an app forwarding the Amplitude device ID to Airbridge via `setAmplitudeDeviceId()` got `null`, so the install never matched.

Linear: [SDKF-73](https://linear.app/amplitude/issue/SDKF-73) (customer investigation: [SDKF-74](https://linear.app/amplitude/issue/SDKF-74)).

### Root cause

The underlying `com.amplitude:analytics-android` SDK assigns the device ID and restores the session ID on a background coroutine exposed as `Amplitude.isBuilt` (a `Deferred<Boolean>`). `getDeviceId()` reads `store.deviceId` and `sessionId` reads `Timeline._sessionId` — both return their empty state (`null` / `-1`) until that coroutine completes. The plugin's handlers read them synchronously and replied immediately, so a Dart caller could observe the pre-build state. The native SDK's own identity/session-dependent operations all `isBuilt.await()` first (e.g. `Timeline.kt` awaits `isBuilt` before restoring the session); the plugin just wasn't following that convention.

Note the native SDK's public docs show `amplitude.getDeviceId()` as a plain synchronous call with no null/timing caveat and never mention `isBuilt`, so this gap isn't discoverable from the documented API — the fix makes the plugin behave the way the docs imply.

### Fix

Gate the `getDeviceId` and `getSessionId` replies on `amplitude.isBuilt` via `invokeOnCompletion`, posting the `MethodChannel.Result` back on the main thread. A build that completes exceptionally resolves to `null` (both getters are nullable by contract on the Dart side) rather than surfacing a `PlatformException`.

Scope is deliberately limited to the read-side getters. Gating the `init` reply on `isBuilt` (to make Dart's `isBuilt` a faithful proxy of the native build) was considered but rejected here: it would put a low-probability-but-unrecoverable hang on the app-startup critical path (no timeout on the Dart `init` future), and gating the getters already resolves the issue.

**iOS needs no equivalent change** — the Swift SDK assigns identity and session state synchronously in its constructor, so `getDeviceId`/`getSessionId` are already valid once `init` returns.

## Changes

- `AmplitudeFlutterPlugin.kt`: `getDeviceId` and `getSessionId` handlers now wait for `amplitude.isBuilt` before reading/replying; adds a `Handler(Looper.getMainLooper())` to deliver results on the main thread.
- `AmplitudeFlutterPluginTest.kt`: adds `getDeviceIdReturnsNonNullAfterInit` and `getSessionIdReturnsValueAfterInit`.

## Testing

⚠️ **Not validated by automated tests — please verify before merging.**

- Both main and test Kotlin **compile** cleanly (`compileDebugKotlin` + `compileDebugUnitTestKotlin` succeed).
- The Kotlin unit tests **could not be run to green locally**: every test in `AmplitudeFlutterPluginTest` — including pre-existing, unmodified ones — fails at `getConfiguration` with `java.lang.ClassCastException: JSONObject cannot be cast to Map`, a pre-existing local-harness/Flutter-engine incompatibility in `MethodCall` decoding, unrelated to this change (confirmed by running an untouched test and seeing the same failure).
- **CI does not run the Android Kotlin tests at all** — `.github/workflows/ci.yml` runs only `flutter analyze` and `flutter test` (Dart). Neither the new nor existing Kotlin tests are exercised by CI.

Recommend a maintainer validate on a device (confirm `getDeviceId()`/`getSessionId()` return real values after init on first launch), or via a follow-up that wires the Android unit tests into CI + fixes the local harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes identity/session read timing on the Flutter–Android bridge; behavior is more correct but async replies could affect callers that assumed instant responses, though Dart already awaits the channel.
> 
> **Overview**
> Fixes a **first-launch race on Android** where Dart `getDeviceId()` / `getSessionId()` could return `null` or `-1` even when callers had already awaited init, because the native analytics SDK assigns device ID and restores session ID on the `amplitude.isBuilt` coroutine.
> 
> **`getDeviceId` and `getSessionId`** in `AmplitudeFlutterPlugin.kt` no longer read and reply synchronously. They register on `amplitude.isBuilt.invokeOnCompletion`, then post the `MethodChannel` result on the main thread via a `Handler(Looper.getMainLooper())`. If the build fails, both paths resolve to **`null`** instead of throwing to Dart.
> 
> Unit tests add **`awaitInitialized()`** (await `isBuilt` + idle main looper) and assert non-empty device ID and a delivered session ID after init.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c51341fbbd49e654a8e060cb06efb5b6c5058af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->