### PR TITLE
test(android): fix plugin unit test harness and run it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,35 @@ jobs:
 
       - name: Test
         run: flutter test
+
+  android-unit-test:
+    name: Android plugin unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      - name: Setup Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          channel: 'stable'
+
+      - name: Install packages
+        working-directory: example
+        run: flutter pub get
+
+      # Generates android/local.properties and the Gradle wrapper (both gitignored)
+      # without doing a full APK build, so ./gradlew is available below.
+      - name: Generate Android build config
+        working-directory: example
+        run: flutter build apk --config-only
+
+      - name: Run plugin unit tests
+        working-directory: example/android
+        run: ./gradlew :amplitude_flutter:testDebugUnitTest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       # without doing a full APK build, so ./gradlew is available below.
       - name: Generate Android build config
         working-directory: example
-        run: flutter build apk --config-only
+        run: flutter build apk --config-only --no-pub
 
       - name: Run plugin unit tests
         working-directory: example/android

--- a/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt
@@ -8,11 +8,11 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
 import org.robolectric.annotation.Config
 
 @Config(manifest=Config.NONE)
@@ -21,7 +21,10 @@ class AmplitudeFlutterPluginTest {
     private val plugin = AmplitudeFlutterPlugin()
     private val result = spyk<MethodChannel.Result>()
     private val binding = mockk<FlutterPlugin.FlutterPluginBinding>(relaxed = true)
-    private val context = mockk<Context>()
+    // Use Robolectric's real application Context so the Amplitude SDK's storage
+    // layer (SharedPreferences, file dirs) works as it does at runtime. A bare
+    // mockk<Context>() has no answer for getSharedPreferences() and blows up.
+    private val context: Context = RuntimeEnvironment.getApplication()
 
     private lateinit var testConfigurationMap: MutableMap<String, Any?>
     private lateinit var testEventMap: MutableMap<String, Any?>
@@ -42,7 +45,7 @@ class AmplitudeFlutterPluginTest {
             "serverZone" to "us",
             "serverUrl" to null,
             "minTimeBetweenSessionsMillis" to 5 * 60 * 1000, // 5 minutes
-            "defaultTracking" to JSONObject(mapOf(
+            "defaultTracking" to mapOf(
                 "sessions" to true,
                 "appLifecycles" to false,
                 "deepLinks" to false,
@@ -50,8 +53,8 @@ class AmplitudeFlutterPluginTest {
                 "pageViews" to true,
                 "formInteractions" to true,
                 "fileDownloads" to true
-            )),
-            "trackingOptions" to JSONObject(mapOf(
+            ),
+            "trackingOptions" to mapOf(
                 "ipAddress" to true,
                 "language" to true,
                 "platform" to true,
@@ -71,7 +74,7 @@ class AmplitudeFlutterPluginTest {
                 "latLag" to true,
                 "apiLevel" to true,
                 "idfv" to true
-            )),
+            ),
             "enableCoppaControl" to false,
             "flushEventsOnClose" to true,
             "identifyBatchIntervalMillis" to 30 * 1000,
@@ -116,16 +119,16 @@ class AmplitudeFlutterPluginTest {
             "language" to null,
             "library" to null,
             "ip" to null,
-            "plan" to JSONObject(mapOf(
+            "plan" to mapOf(
                 "branch" to null,
                 "source" to null,
                 "version" to null,
                 "versionId" to null,
-            )),
-            "ingestion_metadata" to JSONObject(mapOf(
+            ),
+            "ingestion_metadata" to mapOf(
                 "sourceName" to null,
                 "sourceVersion" to null,
-            )),
+            ),
             "revenue" to null,
             "price" to null,
             "quantity" to null,
@@ -143,7 +146,7 @@ class AmplitudeFlutterPluginTest {
 
     @Test
     fun shouldInit() {
-        val methodCall = MethodCall("init", JSONObject(testConfigurationMap))
+        val methodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("init called..") }
@@ -151,10 +154,10 @@ class AmplitudeFlutterPluginTest {
 
     @Test
     fun shouldTrack() {
-        val initMethodCall = MethodCall("init", JSONObject(testConfigurationMap))
+        val initMethodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(initMethodCall, result)
 
-        val methodCall = MethodCall("track", JSONObject(mapOf("instanceName" to "\$default_instance", "event" to testEventMap)))
+        val methodCall = MethodCall("track", mapOf("instanceName" to "\$default_instance", "event" to testEventMap))
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("track called..") }
@@ -162,14 +165,14 @@ class AmplitudeFlutterPluginTest {
 
     @Test
     fun shouldIdentify() {
-        val initMethodCall = MethodCall("init", JSONObject(testConfigurationMap))
+        val initMethodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(initMethodCall, result)
 
         testEventMap["event_type"] = "\$identify"
         testEventMap["user_properties"] = mapOf(
             "\$set" to mapOf("testProperty" to "testValue")
         )
-        val methodCall = MethodCall("identify", JSONObject(mapOf("instanceName" to "\$default_instance", "event" to testEventMap)))
+        val methodCall = MethodCall("identify", mapOf("instanceName" to "\$default_instance", "event" to testEventMap))
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("identify called..") }
@@ -177,7 +180,7 @@ class AmplitudeFlutterPluginTest {
 
     @Test
     fun shouldGroupIdentify() {
-        val initMethodCall = MethodCall("init", JSONObject(testConfigurationMap))
+        val initMethodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(initMethodCall, result)
 
         testEventMap["event_type"] = "\$groupidentify"
@@ -187,7 +190,7 @@ class AmplitudeFlutterPluginTest {
         testEventMap["group_properties"] = mapOf(
             "\$set" to mapOf("testProperty" to "testValue")
         )
-        val methodCall = MethodCall("groupIdentify", JSONObject(mapOf("instanceName" to "\$default_instance", "event" to testEventMap)))
+        val methodCall = MethodCall("groupIdentify", mapOf("instanceName" to "\$default_instance", "event" to testEventMap))
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("groupIdentify called..") }
@@ -195,7 +198,7 @@ class AmplitudeFlutterPluginTest {
 
     @Test
     fun shouldSetGroup() {
-        val initMethodCall = MethodCall("init", JSONObject(testConfigurationMap))
+        val initMethodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(initMethodCall, result)
 
         testEventMap["event_type"] = "\$identify"
@@ -205,7 +208,7 @@ class AmplitudeFlutterPluginTest {
         testEventMap["user_properties"] = mapOf(
             "\$set" to mapOf("testProperty" to "testValue")
         )
-        val methodCall = MethodCall("setGroup", JSONObject(mapOf("instanceName" to "\$default_instance", "event" to testEventMap)))
+        val methodCall = MethodCall("setGroup", mapOf("instanceName" to "\$default_instance", "event" to testEventMap))
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("setGroup called..") }
@@ -213,7 +216,7 @@ class AmplitudeFlutterPluginTest {
 
     @Test
     fun shouldRevenue() {
-        val initMethodCall = MethodCall("init", JSONObject(testConfigurationMap))
+        val initMethodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(initMethodCall, result)
 
         testEventMap["event_type"] = "revenue_amount"
@@ -225,7 +228,7 @@ class AmplitudeFlutterPluginTest {
             "\$quantity" to "testQuantity",
             "\$productId" to "testProductId"
         )
-        val methodCall = MethodCall("revenue", JSONObject(mapOf("instanceName" to "\$default_instance", "event" to testEventMap)))
+        val methodCall = MethodCall("revenue", mapOf("instanceName" to "\$default_instance", "event" to testEventMap))
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("revenue called..") }
@@ -233,10 +236,10 @@ class AmplitudeFlutterPluginTest {
 
     @Test
     fun shouldSetUserId() {
-        val initMethodCall = MethodCall("init", JSONObject(testConfigurationMap))
+        val initMethodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(initMethodCall, result)
 
-        val methodCall = MethodCall("setUserId", JSONObject(mapOf("instanceName" to "\$default_instance", "properties" to mapOf("setUserId" to "testUserId"))))
+        val methodCall = MethodCall("setUserId", mapOf("instanceName" to "\$default_instance", "properties" to mapOf("setUserId" to "testUserId")))
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("setUserId called..") }
@@ -244,10 +247,10 @@ class AmplitudeFlutterPluginTest {
 
     @Test
     fun shouldSetDeviceId() {
-        val initMethodCall = MethodCall("init", JSONObject(testConfigurationMap))
+        val initMethodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(initMethodCall, result)
 
-        val methodCall = MethodCall("setDeviceId", JSONObject(mapOf("instanceName" to "\$default_instance", "properties" to mapOf("setDeviceId" to "testDeviceId"))))
+        val methodCall = MethodCall("setDeviceId", mapOf("instanceName" to "\$default_instance", "properties" to mapOf("setDeviceId" to "testDeviceId")))
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("setDeviceId called..") }
@@ -255,10 +258,10 @@ class AmplitudeFlutterPluginTest {
 
     @Test
     fun shouldReset() {
-        val initMethodCall = MethodCall("init", JSONObject(testConfigurationMap))
+        val initMethodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(initMethodCall, result)
 
-        val methodCall = MethodCall("reset", JSONObject(mapOf("instanceName" to "\$default_instance")))
+        val methodCall = MethodCall("reset", mapOf("instanceName" to "\$default_instance"))
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("reset called..") }
@@ -266,10 +269,10 @@ class AmplitudeFlutterPluginTest {
 
     @Test
     fun shouldFlush() {
-        val initMethodCall = MethodCall("init", JSONObject(testConfigurationMap))
+        val initMethodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(initMethodCall, result)
 
-        val methodCall = MethodCall("flush", JSONObject(mapOf("instanceName" to "\$default_instance")))
+        val methodCall = MethodCall("flush", mapOf("instanceName" to "\$default_instance"))
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("flush called..") }

--- a/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt
+++ b/android/src/test/kotlin/com/amplitude/amplitude_flutter/AmplitudeFlutterPluginTest.kt
@@ -2,6 +2,7 @@ package com.amplitude.amplitude_flutter
 
 import android.content.Context
 import android.os.Looper
+import com.amplitude.android.AutocaptureOption
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -10,6 +11,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -48,6 +50,10 @@ class AmplitudeFlutterPluginTest {
             "serverZone" to "us",
             "serverUrl" to null,
             "minTimeBetweenSessionsMillis" to 5 * 60 * 1000, // 5 minutes
+            // Dart's Configuration.toMap() still sends the deprecated
+            // defaultTracking map, but the plugin reads only the resolved
+            // autocapture value (see Configuration._resolveAutocapture). Send
+            // both, as the Dart side does.
             "defaultTracking" to mapOf(
                 "sessions" to true,
                 "appLifecycles" to false,
@@ -56,6 +62,20 @@ class AmplitudeFlutterPluginTest {
                 "pageViews" to true,
                 "formInteractions" to true,
                 "fileDownloads" to true
+            ),
+            // The autocapture map Dart derives from the defaultTracking above.
+            "autocapture" to mapOf(
+                "sessions" to true,
+                "attribution" to mapOf(
+                    "initialEmptyValue" to "EMPTY",
+                    "resetSessionOnNewCampaign" to false
+                ),
+                "pageViews" to mapOf(
+                    "trackHistoryChanges" to "all",
+                    "eventType" to ""
+                ),
+                "appLifecycles" to false,
+                "deepLinks" to false
             ),
             "trackingOptions" to mapOf(
                 "ipAddress" to true,
@@ -153,12 +173,45 @@ class AmplitudeFlutterPluginTest {
         shadowOf(Looper.getMainLooper()).idle()
     }
 
+    private fun autocaptureOf(instanceName: String = "\$default_instance"): Set<AutocaptureOption> {
+        val amp = AmplitudeFlutterPlugin.getAmplitudeInstanceById(instanceName)!!
+        // Amplitude.configuration is typed as the core Configuration; autocapture
+        // is declared on the Android subclass.
+        return (amp.configuration as com.amplitude.android.Configuration).autocapture
+    }
+
     @Test
     fun shouldInit() {
         val methodCall = MethodCall("init", testConfigurationMap)
         plugin.onMethodCall(methodCall, result)
 
         verify(exactly = 1) { result.success("init called..") }
+    }
+
+    @Test
+    fun initAppliesAutocaptureFromMap() {
+        // Use a combination that differs from the native SDK defaults, so this
+        // only passes if the plugin actually parsed the autocapture map.
+        testConfigurationMap["autocapture"] = mapOf(
+            "sessions" to false,
+            "appLifecycles" to true,
+            "deepLinks" to true
+        )
+        plugin.onMethodCall(MethodCall("init", testConfigurationMap), result)
+
+        assertEquals(
+            setOf(AutocaptureOption.APP_LIFECYCLES, AutocaptureOption.DEEP_LINKS),
+            autocaptureOf()
+        )
+    }
+
+    @Test
+    fun initDisablesAutocaptureWhenFalse() {
+        // AutocaptureDisabled serializes to `false` rather than a map.
+        testConfigurationMap["autocapture"] = false
+        plugin.onMethodCall(MethodCall("init", testConfigurationMap), result)
+
+        assertEquals(emptySet<AutocaptureOption>(), autocaptureOf())
     }
 
     @Test


### PR DESCRIPTION
## Summary
The Android Kotlin plugin unit tests (`AmplitudeFlutterPluginTest`) were never executed by CI and failed when run locally.

### The bug
Every test that reached the `init` method-channel handler died in `getConfiguration` with:
```
java.lang.ClassCastException: org.json.JSONObject cannot be cast to java.util.Map
```
The tests built `MethodCall` arguments as `JSONObject`, so `call.argument(...)` returned nested `JSONObject`s that the plugin casts to `Map`. In production, Flutter's `StandardMethodCodec` decodes arguments to plain `Map`s.

A second harness issue surfaced once the cast was fixed: `context` was a bare `mockk<Context>()`, so the SDK storage layer blew up on an unstubbed `getSharedPreferences(...)`.

### Changes
- Build `MethodCall` arguments (and nested config/event objects) as plain `Map`s, so `call.argument(...)` returns `Map`s exactly as at runtime.
- Use Robolectric's real application `Context` instead of a bare mock, so the SDK's `SharedPreferences`/file storage works.
- Add a CI job running `:amplitude_flutter:testDebugUnitTest` so plugin-layer regressions are caught.

### Verification
`./gradlew :amplitude_flutter:testDebugUnitTest` → **10 tests, 0 failures, 0 skipped**.

Context: this gap is why the device-ID race test (`getDeviceIdReturnsNonNullAfterInit`) from #310 can't be validated by CI today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and CI-only changes; no production plugin or Dart code modified.
> 
> **Overview**
> **Fixes Android plugin unit tests** so they match runtime method-channel decoding and can run in CI.
> 
> `AmplitudeFlutterPluginTest` now passes **`MethodCall` arguments as plain `Map`s** (not `JSONObject`), matching Flutter’s `StandardMethodCodec` and avoiding `ClassCastException` in `getConfiguration`. Test setup uses **Robolectric’s application `Context`** so the Amplitude SDK’s `SharedPreferences` storage works. Fixture config adds the **`autocapture` map** alongside deprecated `defaultTracking`, mirroring Dart’s `Configuration.toMap()`.
> 
> **New coverage:** `initAppliesAutocaptureFromMap` and `initDisablesAutocaptureWhenFalse` assert autocapture parsing on the native `Configuration`.
> 
> **CI:** Adds an **`android-unit-test`** job (Java 17, Flutter stable, `flutter build apk --config-only` in `example`, then `./gradlew :amplitude_flutter:testDebugUnitTest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ca13d1e98fe588730d35028b7302aa3307f3544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->