### PR TITLE
ci(ios): run plugin example unit tests and fix engine framework path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,14 @@ jobs:
       - name: Run plugin unit tests
         working-directory: example/ios
         run: |
+          # Pick any available iPhone simulator so we don't pin a device
+          # name/OS that a future runner image may not ship.
+          UDID=$(xcrun simctl list devices available --json \
+            | python3 -c "import json,sys; devs=json.load(sys.stdin)['devices']; print(next(d['udid'] for rt in devs for d in devs[rt] if d.get('isAvailable') and d['name'].startswith('iPhone')))")
+          echo "Using simulator $UDID"
           xcodebuild test \
             -workspace Runner.xcworkspace \
             -scheme Runner \
-            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -destination "id=$UDID" \
+            -parallel-testing-enabled NO \
             CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,12 @@ jobs:
         with:
           channel: 'stable'
 
+      # The plugin integrates via CocoaPods (podspec + Podfile). Newer Flutter
+      # enables Swift Package Manager by default, which fails on this project
+      # with a package-identity mismatch. Force the CocoaPods path.
+      - name: Use CocoaPods (disable Swift Package Manager)
+        run: flutter config --no-enable-swift-package-manager
+
       - name: Install packages
         working-directory: example
         run: flutter pub get

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,42 @@ jobs:
       - name: Run plugin unit tests
         working-directory: example/android
         run: ./gradlew :amplitude_flutter:testDebugUnitTest
+
+  ios-unit-test:
+    name: iOS plugin unit tests
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          channel: 'stable'
+
+      - name: Install packages
+        working-directory: example
+        run: flutter pub get
+
+      # Download the iOS engine artifacts (Flutter.xcframework) that the Runner
+      # project links against via $(FLUTTER_ROOT).
+      - name: Precache iOS artifacts
+        run: flutter precache --ios
+
+      # Generates ios/Flutter/Generated.xcconfig (defines FLUTTER_ROOT) without a build.
+      - name: Generate iOS build config
+        working-directory: example
+        run: flutter build ios --config-only --no-codesign
+
+      - name: Install CocoaPods
+        working-directory: example/ios
+        run: pod install
+
+      - name: Run plugin unit tests
+        working-directory: example/ios
+        run: |
+          xcodebuild test \
+            -workspace Runner.xcworkspace \
+            -scheme Runner \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            CODE_SIGNING_ALLOWED=NO

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       # Generates ios/Flutter/Generated.xcconfig (defines FLUTTER_ROOT) without a build.
       - name: Generate iOS build config
         working-directory: example
-        run: flutter build ios --config-only --no-codesign
+        run: flutter build ios --config-only --no-codesign --no-pub
 
       - name: Install CocoaPods
         working-directory: example/ios

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -43,7 +43,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		0001093C2E1DDA40006187A7 /* Flutter.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:S8QB4VV633:FLUTTER.IO LLC"; lastKnownFileType = wrapper.xcframework; name = Flutter.xcframework; path = ../../../flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework; sourceTree = "<group>"; };
+		0001093C2E1DDA40006187A7 /* Flutter.xcframework */ = {isa = PBXFileReference; expectedSignature = "AppleDeveloperProgram:S8QB4VV633:FLUTTER.IO LLC"; lastKnownFileType = wrapper.xcframework; name = Flutter.xcframework; path = bin/cache/artifacts/engine/ios/Flutter.xcframework; sourceTree = FLUTTER_ROOT; };
 		0FE6C8EBAA6DB72C81AA82BF /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };


### PR DESCRIPTION
## Summary
> **Stacked on #311** (base branch `claude/friendly-gould-aebf27`). Review/merge that one first; the diff below is iOS-only.

Wires the iOS plugin example's `RunnerTests` target into CI — and fixes the pre-existing bug that made the iOS example unbuildable anywhere but the original author's machine.

### The bug
`example/ios/Runner.xcodeproj/project.pbxproj` referenced the Flutter engine via a hardcoded relative path:
```
path = ../../../flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework
```
From `example/ios`, that only resolves when the Flutter SDK sits three levels above the checkout. In every other layout (CI runners, git worktrees, most dev machines) the build fails with:
```
error: There is no XCFramework found at '.../flutter/bin/cache/artifacts/engine/ios/Flutter.xcframework'
```
A full `flutter build ios` does **not** regenerate this reference, so the iOS example was effectively unbuildable outside that one layout. This is almost certainly why there was no iOS CI job.

### Changes
- Reference the engine relative to the `FLUTTER_ROOT` build setting (which Flutter defines per-environment in `Generated.xcconfig`) instead of a hardcoded relative path, so the example builds anywhere.
- Add a `macos-latest` CI job that runs the `RunnerTests` target via `xcodebuild test`.

### Verification
`xcodebuild test -workspace Runner.xcworkspace -scheme Runner -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.4' CODE_SIGNING_ALLOWED=NO` → **TEST SUCCEEDED**, `RunnerTests.testExample()` passed.

### Note
`RunnerTests.swift` currently contains only an empty placeholder `testExample()` — this job verifies the iOS example **compiles and links** and gives a home for real plugin-layer tests, but does not yet assert plugin behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and example Xcode project path fix only; no changes to plugin runtime behavior or shipped SDK code.
> 
> **Overview**
> Fixes the example iOS app so it can **link the Flutter engine on any machine/CI layout**, and adds a **macOS CI job** that runs the example’s `RunnerTests` via `xcodebuild`.
> 
> In `project.pbxproj`, the `Flutter.xcframework` reference no longer uses a hardcoded `../../../flutter/...` path; it resolves under **`FLUTTER_ROOT`** (`bin/cache/artifacts/engine/ios/Flutter.xcframework`), matching what Flutter writes in `Generated.xcconfig`.
> 
> The new **`ios-unit-test`** workflow mirrors the Android job: stable Flutter, `flutter pub get`, **`--no-enable-swift-package-manager`** (CocoaPods path), `flutter precache --ios`, config-only iOS build, `pod install`, then **`xcodebuild test`** on an auto-selected iPhone simulator with signing disabled. Today’s tests are still a placeholder—this mainly guards **compile/link** for the iOS example.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08bf7a7a9a65067f8df0b2676cba70bdcf2ceb6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->