### PR TITLE
fix(ios): apply Configuration.deviceId and surface init failures

### DIFF
--- a/darwin/amplitude_flutter/Sources/amplitude_flutter/SwiftAmplitudeFlutterPlugin.swift
+++ b/darwin/amplitude_flutter/Sources/amplitude_flutter/SwiftAmplitudeFlutterPlugin.swift
@@ -47,25 +47,46 @@ internal var pluginInstance: SwiftAmplitudeFlutterPlugin?
         if call.method == "init" {
             guard let configArgs = call.arguments as? [String: Any] else {
                 print("\(call.method) called but call.arguments type casting failed.")
+                result(FlutterError(
+                    code: "init_failed",
+                    message: "init called but call.arguments type casting failed.",
+                    details: nil))
                 return
             }
 
-            var amplitude: Amplitude?
+            // Surface initialization failures back to Dart so `_init()` can resolve
+            // `isBuilt` to false. Reporting success here regardless would make
+            // `isBuilt` always true even when the instance was never created.
+            let amplitude: Amplitude
             do {
                 amplitude = Amplitude(configuration: try getConfiguration(args: configArgs))
-                instances[amplitude!.configuration.instanceName] = amplitude
             } catch {
-                print("Initialization failed.")
+                print("Amplitude initialization failed: \(error)")
+                result(FlutterError(
+                    code: "init_failed",
+                    message: "Amplitude initialization failed: \(error.localizedDescription)",
+                    details: nil))
+                return
+            }
+
+            instances[amplitude.configuration.instanceName] = amplitude
+
+            // AmplitudeSwift's Configuration has no deviceId field, so apply the
+            // deviceId passed from Dart Configuration right after construction.
+            // This mirrors Android (ConfigurationBuilder.deviceId) so a configured
+            // deviceId is honored on iOS/macOS as well.
+            if let deviceId = configArgs["deviceId"] as? String {
+                amplitude.setDeviceId(deviceId: deviceId)
             }
 
             // Set library
-            amplitude?.add(
+            amplitude.add(
                 plugin: FlutterLibraryPlugin(
                     library: configArgs["library"] as? String ?? "amplitude-flutter/unknown"
                 )
             )
 
-            amplitude?.logger?.debug(message: "Amplitude has been successfully initialized.")
+            amplitude.logger?.debug(message: "Amplitude has been successfully initialized.")
 
             result("init called..")
             return

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -2,11 +2,69 @@ import Flutter
 import UIKit
 import XCTest
 
+import AmplitudeSwift
+@testable import amplitude_flutter
+
 class RunnerTests: XCTestCase {
 
-  func testExample() {
-    // If you add code to the Runner application, consider adding tests here.
-    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  /// Sends an `init` method call through the plugin and returns the resulting
+  /// Amplitude instance created for the given `instanceName`.
+  private func initPlugin(arguments: [String: Any], instanceName: String) -> Amplitude? {
+    let plugin = SwiftAmplitudeFlutterPlugin()
+    let call = FlutterMethodCall(methodName: "init", arguments: arguments)
+    plugin.handle(call) { _ in }
+    return plugin.instances[instanceName]
+  }
+
+  /// A configured `deviceId` (passed from Dart `Configuration.deviceId`) must be
+  /// applied to the native Amplitude instance, matching Android semantics.
+  func testInitAppliesConfiguredDeviceId() {
+    let instanceName = "test_device_id_\(UUID().uuidString)"
+    let expectedDeviceId = "configured-device-id-\(UUID().uuidString)"
+
+    let amplitude = initPlugin(
+      arguments: [
+        "apiKey": "test-api-key",
+        "instanceName": instanceName,
+        "deviceId": expectedDeviceId,
+      ],
+      instanceName: instanceName
+    )
+
+    XCTAssertNotNil(amplitude, "init should create an Amplitude instance")
+    XCTAssertEqual(amplitude?.getDeviceId(), expectedDeviceId)
+  }
+
+  /// When no `deviceId` is configured, init still succeeds and the SDK falls back
+  /// to its own generated device id rather than the configured value.
+  func testInitWithoutDeviceIdFallsBackToGeneratedId() {
+    let instanceName = "test_no_device_id_\(UUID().uuidString)"
+
+    let amplitude = initPlugin(
+      arguments: [
+        "apiKey": "test-api-key",
+        "instanceName": instanceName,
+      ],
+      instanceName: instanceName
+    )
+
+    XCTAssertNotNil(amplitude, "init should create an Amplitude instance")
+    XCTAssertNotNil(amplitude?.getDeviceId(), "SDK should generate a device id when none is configured")
+  }
+
+  /// A failed init (e.g. missing apiKey) must be reported back to Dart as a
+  /// FlutterError so `isBuilt` resolves to false, rather than silently reporting
+  /// success with no instance created.
+  func testInitWithMissingApiKeyReportsFlutterError() {
+    let instanceName = "test_missing_api_key_\(UUID().uuidString)"
+    let plugin = SwiftAmplitudeFlutterPlugin()
+    let call = FlutterMethodCall(methodName: "init", arguments: ["instanceName": instanceName])
+
+    var captured: Any?
+    plugin.handle(call) { captured = $0 }
+
+    XCTAssertTrue(captured is FlutterError, "init without apiKey should report a FlutterError")
+    XCTAssertNil(plugin.instances[instanceName], "no instance should be created when init fails")
   }
 
 }


### PR DESCRIPTION
## Summary

- **iOS/macOS ignored `Configuration.deviceId`.** Android applies it via `ConfigurationBuilder.deviceId`, but the Swift plugin's `getConfiguration` never read the arg, so the value was silently dropped. AmplitudeSwift's `Configuration` has **no** `deviceId` field, so the configured value is now applied via `setDeviceId()` immediately after constructing the instance — the [documented iOS override path](https://amplitude.com/docs/sdks/analytics/ios/ios-swift-sdk#custom-device-id), which sits at the top of the [device-id lifecycle](https://amplitude.com/docs/sdks/analytics/ios/ios-swift-sdk#device-id-lifecycle) (ahead of IDFV / random UUID). `identity.deviceId` is set synchronously, so this is race-free. Result: `Configuration.deviceId` is now honored on iOS/macOS, matching Android.

- **Hardened init error handling in the same handler.** A thrown `getConfiguration` error (e.g. missing `apiKey`) was swallowed with a `print` and the method *still* called `result("init called..")`, so Dart's `_init()` never saw a failure and `isBuilt` was **always `true` even when init failed**. Failures — and the previously silent arguments-cast `guard` — now return a `FlutterError`, so `_init()` resolves `isBuilt` to `false` as its doc promises. `amplitude` is bound non-optionally, removing the force-unwraps.

## Why

This is the iOS counterpart to merged #282 (Android `deviceId`). `Configuration.deviceId` is the customer workaround for the `getDeviceId()`-returns-null-after-`isBuilt` race — it previously only worked on Android.

## Tests

- Added `RunnerTests` covering: configured `deviceId` is honored, a missing `deviceId` falls back to an SDK-generated id, and a failed init reports a `FlutterError` with no instance created.
- `flutter test` (Dart suite) is green.
- ⚠️ **Verification caveat:** iOS plugin unit tests are **not run by CI yet** (`ci.yml` only runs `flutter test`; native harness work is in flight in #311 / #312). These new XCTests were written against the plugin's internals but must be run via Xcode until CI executes them — I could not run them in my environment.

## Scope & follow-up

This fixes only the **`deviceId`** half of #281. **`userId` from `Configuration` is still ignored on _both_ iOS and Android** — #282 fixed only Android's `deviceId`, and neither `getConfiguration` (iOS) nor the Android `ConfigurationBuilder` block applies `userId`. Left as a deliberate follow-up; not in scope here.

## Related

- Addresses the `deviceId` portion of #281 (does **not** fully close it — `userId` remains)
- Refs #188 (the customer race that prompted this; remaining scope is web-only per maintainer)
- Refs Linear **SDKF-73** (primary ticket), **SDKF-74** (originating Zendesk report)
- iOS counterpart to #282; complements #310 (Android `getDeviceId`/`isBuilt` race) and #311 / #312 (iOS plugin test + CI harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
