### PR TITLE
feat(autocapture): capture Flutter widget taps as element interaction events

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,12 +6,13 @@ import 'my_app.dart';
 
 void main() {
   // On Flutter web with the default CanvasKit renderer, the Amplitude Browser
-  // SDK's DOM-based autocapture (elementInteractions / formInteractions /
-  // fileDownloads) can only observe Flutter's accessibility semantics tree.
-  // That tree is off until something enables it, so enable it here to
-  // demonstrate web click/form capture. Enabling semantics app-wide has a
-  // runtime cost and known side effects, so only do this if you actually want
-  // DOM-based web capture.
+  // SDK's DOM-based autocapture (formInteractions / fileDownloads) can only
+  // observe Flutter's accessibility semantics tree. That tree is off until
+  // something enables it, so enable it here to demonstrate web form capture.
+  // Enabling semantics app-wide has a runtime cost and known side effects, so
+  // only do this if you actually want DOM-based web capture. Element
+  // interactions do not need it: the AmplitudeElementTapDetector wrapping the
+  // app captures widget taps on every platform with semantics off.
   if (kIsWeb) {
     WidgetsFlutterBinding.ensureInitialized();
     SemanticsBinding.instance.ensureSemantics();

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -7,6 +7,7 @@ import 'package:amplitude_flutter/autocapture/element_interactions.dart';
 import 'package:amplitude_flutter/autocapture/page_views.dart';
 import 'package:amplitude_flutter/configuration.dart';
 import 'package:amplitude_flutter/constants.dart';
+import 'package:amplitude_flutter/observers/amplitude_element_tap_detector.dart';
 import 'package:amplitude_flutter/observers/amplitude_navigator_observer.dart';
 import 'package:flutter/material.dart';
 
@@ -89,78 +90,84 @@ class _MyAppState extends State<MyApp> {
     return AppState(
       analytics: analytics,
       setMessage: setMessage,
-      child: MaterialApp(
-        theme: ThemeData(
-            inputDecorationTheme: InputDecorationTheme(
-                contentPadding: const EdgeInsets.all(8), filled: true)),
-        navigatorObservers: [_navigatorObserver],
-        routes: {
-          '/details': (context) => const DetailsScreen(),
-        },
-        home: Scaffold(
-          appBar: AppBar(
-            title: const Text('Amplitude Flutter'),
-          ),
-          body: Padding(
-            padding: const EdgeInsets.all(10.0),
-            child: ListView(
-              children: <Widget>[
-                DeviceIdForm(),
-                divider,
-                UserIdForm(),
-                divider,
-                ResetForm(),
-                divider,
-                SessionIdForm(),
-                divider,
-                EventForm(),
-                divider,
-                IdentifyForm(),
-                divider,
-                GroupForm(),
-                divider,
-                GroupIdentifyForm(),
-                divider,
-                RevenueForm(),
-                divider,
-                // FlushThresholdForm(),
-                // divider,
-                Row(
-                  children: [
-                    Expanded(
-                      child: ElevatedButton(
-                        child: const Text('Opt Out'),
-                        onPressed: () {
-                          analytics.setOptOut(true);
-                          setMessage('Opted out — tracking disabled.');
-                        },
+      // Taps on interactive widgets are autocaptured as
+      // `[Amplitude] Element Interacted` events on every platform.
+      child: AmplitudeElementTapDetector(
+        amplitude: analytics,
+        child: MaterialApp(
+          theme: ThemeData(
+              inputDecorationTheme: InputDecorationTheme(
+                  contentPadding: const EdgeInsets.all(8), filled: true)),
+          navigatorObservers: [_navigatorObserver],
+          routes: {
+            '/details': (context) => const DetailsScreen(),
+          },
+          home: Scaffold(
+            appBar: AppBar(
+              title: const Text('Amplitude Flutter'),
+            ),
+            body: Padding(
+              padding: const EdgeInsets.all(10.0),
+              child: ListView(
+                children: <Widget>[
+                  DeviceIdForm(),
+                  divider,
+                  UserIdForm(),
+                  divider,
+                  ResetForm(),
+                  divider,
+                  SessionIdForm(),
+                  divider,
+                  EventForm(),
+                  divider,
+                  IdentifyForm(),
+                  divider,
+                  GroupForm(),
+                  divider,
+                  GroupIdentifyForm(),
+                  divider,
+                  RevenueForm(),
+                  divider,
+                  // FlushThresholdForm(),
+                  // divider,
+                  Row(
+                    children: [
+                      Expanded(
+                        child: ElevatedButton(
+                          child: const Text('Opt Out'),
+                          onPressed: () {
+                            analytics.setOptOut(true);
+                            setMessage('Opted out — tracking disabled.');
+                          },
+                        ),
                       ),
-                    ),
-                    const SizedBox(width: 8),
-                    Expanded(
-                      child: ElevatedButton(
-                        child: const Text('Opt In'),
-                        onPressed: () {
-                          analytics.setOptOut(false);
-                          setMessage('Opted in — tracking enabled.');
-                        },
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: ElevatedButton(
+                          child: const Text('Opt In'),
+                          onPressed: () {
+                            analytics.setOptOut(false);
+                            setMessage('Opted in — tracking enabled.');
+                          },
+                        ),
                       ),
-                    ),
-                  ],
-                ),
-                divider,
-                ElevatedButton(
-                  child: const Text('Flush Events'),
-                  onPressed: _flushEvents,
-                ),
-                Builder(
-                  builder: (context) => ElevatedButton(
-                    child: const Text('Open Details Screen'),
-                    onPressed: () => Navigator.of(context).pushNamed('/details'),
+                    ],
                   ),
-                ),
-                Text(_message, style: Theme.of(context).textTheme.bodyLarge)
-              ],
+                  divider,
+                  ElevatedButton(
+                    child: const Text('Flush Events'),
+                    onPressed: _flushEvents,
+                  ),
+                  Builder(
+                    builder: (context) => ElevatedButton(
+                      child: const Text('Open Details Screen'),
+                      onPressed: () =>
+                          Navigator.of(context).pushNamed('/details'),
+                    ),
+                  ),
+                  Text(_message, style: Theme.of(context).textTheme.bodyLarge)
+                ],
+              ),
             ),
           ),
         ),

--- a/example/lib/my_app.dart
+++ b/example/lib/my_app.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 // ignore_for_file: depend_on_referenced_packages
 import 'package:amplitude_flutter/amplitude.dart';
 import 'package:amplitude_flutter/autocapture/autocapture.dart';
-import 'package:amplitude_flutter/autocapture/element_interactions.dart';
 import 'package:amplitude_flutter/autocapture/page_views.dart';
 import 'package:amplitude_flutter/configuration.dart';
 import 'package:amplitude_flutter/constants.dart';
@@ -54,16 +53,18 @@ class _MyAppState extends State<MyApp> {
         // (as `[Amplitude] Screen Viewed`) instead of also as
         // `[Amplitude] Page Viewed`.
         //
-        // The web autocapture options below are all opt-in. The DOM-based ones
-        // (elementInteractions, formInteractions) require the semantics tree,
-        // which main() enables on web. ElementInteractionsOptions() ships
-        // Flutter-aware selectors so clicks on Flutter widgets are captured.
+        // The web autocapture options below are all opt-in. Element
+        // interactions come from the AmplitudeElementTapDetector wrapping the
+        // app in build(), which works on every platform with the semantics
+        // tree off; the Browser SDK's DOM elementInteractions capture is left
+        // off so a tap on web is reported once, not once per mechanism. The
+        // DOM-based formInteractions capture requires the semantics tree,
+        // which main() enables on web.
         autocapture: const AutocaptureOptions(
           screenViews: true,
           pageViews: PageViewsDisabled(),
           appLifecycles: true,
           deepLinks: true,
-          elementInteractions: ElementInteractionsOptions(),
           formInteractions: true,
           pageUrlEnrichment: true,
         )));

--- a/lib/observers/amplitude_element_tap_detector.dart
+++ b/lib/observers/amplitude_element_tap_detector.dart
@@ -1,0 +1,429 @@
+import 'dart:async';
+
+import 'package:flutter/cupertino.dart' show CupertinoButton;
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import '../amplitude.dart';
+import '../events/base_event.dart';
+import 'amplitude_navigator_observer.dart'
+    show AmplitudeNavigatorObserver, screenNameProperty;
+
+/// Event type for autocaptured element interactions. Matches the native
+/// iOS/Android SDK element interaction event so events unify in the
+/// Amplitude UI.
+const String elementInteractedEventType = '[Amplitude] Element Interacted';
+
+/// Event property key for the interaction kind (always `touch`).
+const String elementActionProperty = '[Amplitude] Action';
+
+/// Event property key for the tapped widget's runtime type.
+const String elementTargetClassProperty = '[Amplitude] Target Class';
+
+/// Event property key for the human-readable label of the tapped widget.
+const String elementTargetTextProperty = '[Amplitude] Target Text';
+
+/// Event property key for the developer-assigned [ValueKey] of the tapped
+/// widget, when present.
+const String elementTargetResourceProperty = '[Amplitude] Target Resource';
+
+/// Event property key identifying the UI framework that produced the event.
+const String elementTargetSourceProperty = '[Amplitude] Target Source';
+
+/// Event property key for the widget-type hierarchy above the tapped widget.
+const String elementHierarchyProperty = '[Amplitude] Hierarchy';
+
+/// Maximum length of the reported target text.
+const int _maxTargetTextLength = 128;
+
+/// Maximum number of widget types reported in the hierarchy.
+const int _maxHierarchyDepth = 10;
+
+/// Maximum number of elements visited when deriving a target label.
+const int _maxLabelSearchNodes = 256;
+
+/// Decides whether a tapped widget should be reported. Return `false` to
+/// exclude [widget] and everything inside it from reporting; an interactive
+/// ancestor outside the excluded widget is still reported, if any.
+typedef ElementTargetFilter = bool Function(Widget widget);
+
+/// Supplies the screen name attached to element interaction events.
+typedef ScreenNameProvider = String? Function();
+
+/// Supplies extra event properties merged into every element interaction
+/// event (e.g. organization/tenant context).
+typedef ElementPropertiesProvider = Map<String, Object?> Function();
+
+/// Default [ScreenNameProvider]: the most recent screen tracked by an
+/// [AmplitudeNavigatorObserver].
+String? defaultScreenNameProvider() =>
+    AmplitudeNavigatorObserver.currentScreenName;
+
+/// Autocaptures taps on interactive Flutter widgets as
+/// `[Amplitude] Element Interacted` events.
+///
+/// A Flutter app renders every widget itself — natively it is a single view
+/// (one `FlutterActivity`/`FlutterViewController`, or a canvas on web), so
+/// neither the native SDKs' element interaction autocapture nor the Browser
+/// SDK's DOM click capture can see individual widgets. This widget closes
+/// that gap in Dart: wrap your app with it and taps on buttons, list tiles,
+/// toggles, `InkWell`s, and `GestureDetector`s are captured on every
+/// platform, including web.
+///
+/// ```dart
+/// runApp(AmplitudeElementTapDetector(
+///   amplitude: amplitude,
+///   child: const MyApp(),
+/// ));
+/// ```
+///
+/// On each qualifying tap (a primary-button pointer that goes down and up
+/// within the touch slop) the widget walks its element tree along the tap
+/// position and reports the deepest interactive widget hit. Concrete
+/// controls (buttons, tiles, toggles) take precedence over the generic
+/// gesture handlers they are built from, so an `ElevatedButton` is reported
+/// as `ElevatedButton`, not as its internal `InkWell`.
+///
+/// Reported properties:
+/// * `[Amplitude] Action` — always `touch`.
+/// * `[Amplitude] Target Class` — the widget's runtime type.
+/// * `[Amplitude] Target Text` — the widget's `Semantics` label, `Tooltip`
+///   message, or descendant `Text` content (first available, in that order).
+/// * `[Amplitude] Target Resource` — the widget's [ValueKey] value, if any.
+/// * `[Amplitude] Hierarchy` — up to 10 non-private ancestor widget types.
+/// * `[Amplitude] Screen Name` — from [screenNameProvider]; by default the
+///   last screen tracked by an [AmplitudeNavigatorObserver].
+/// * `[Amplitude] Target Source` — always `Flutter`.
+///
+/// Capture is controlled by constructing this widget (plus [enabled]) and is
+/// deliberately independent of the `elementInteractions` autocapture option:
+/// that option configures the Browser SDK's DOM capture, which on Flutter
+/// web only ever sees the framework's canvas host elements. Typical Flutter
+/// web setups disable the DOM capture and use this widget instead. If both
+/// are enabled on web, taps may be reported twice (once per mechanism).
+///
+/// Analytics must never interfere with the app: all capture work runs after
+/// the tap is released, never blocks gesture handling, and any internal
+/// failure is swallowed (surfaced as a debug-mode log only).
+///
+/// Widgets without discoverable text (e.g. a custom-painted icon inside a
+/// `GestureDetector`) report only their type. Give key interactive widgets a
+/// `Semantics` label, `Tooltip`, or [ValueKey] to make their events
+/// identifiable — this also improves accessibility.
+class AmplitudeElementTapDetector extends StatefulWidget {
+  const AmplitudeElementTapDetector({
+    super.key,
+    required this.amplitude,
+    required this.child,
+    this.enabled = true,
+    this.targetFilter,
+    this.screenNameProvider = defaultScreenNameProvider,
+    this.propertiesProvider,
+  });
+
+  /// The Amplitude instance element interaction events are tracked with.
+  final Amplitude amplitude;
+
+  /// The subtree (typically the whole app) whose taps are captured.
+  final Widget child;
+
+  /// Whether capture is active. When `false` the widget only passes events
+  /// through to [child].
+  final bool enabled;
+
+  /// Optional veto over which widgets are reported.
+  final ElementTargetFilter? targetFilter;
+
+  /// Supplies the `[Amplitude] Screen Name` property.
+  final ScreenNameProvider? screenNameProvider;
+
+  /// Supplies extra properties merged into every captured event.
+  final ElementPropertiesProvider? propertiesProvider;
+
+  @override
+  State<AmplitudeElementTapDetector> createState() =>
+      _AmplitudeElementTapDetectorState();
+}
+
+class _AmplitudeElementTapDetectorState
+    extends State<AmplitudeElementTapDetector> {
+  /// Pointer-down positions by pointer id, to distinguish taps from drags.
+  final Map<int, Offset> _downPositions = {};
+
+  void _onPointerDown(PointerDownEvent event) {
+    if (!widget.enabled) {
+      return;
+    }
+    if (event.buttons & kPrimaryButton == 0) {
+      return;
+    }
+    // Defensive bound: up/cancel normally clears entries, but never let a
+    // platform quirk grow this map without limit.
+    if (_downPositions.length > 20) {
+      _downPositions.clear();
+    }
+    _downPositions[event.pointer] = event.position;
+  }
+
+  void _onPointerCancel(PointerCancelEvent event) {
+    _downPositions.remove(event.pointer);
+  }
+
+  void _onPointerUp(PointerUpEvent event) {
+    final downPosition = _downPositions.remove(event.pointer);
+    if (!widget.enabled || downPosition == null) {
+      return;
+    }
+    if ((event.position - downPosition).distance > kTouchSlop) {
+      return; // A drag or scroll, not a tap.
+    }
+    // Analytics must never interfere with the app, so any failure while
+    // resolving or tracking the target is swallowed and surfaced only in
+    // debug builds.
+    try {
+      final target = _findTarget(event.position);
+      if (target == null) {
+        return;
+      }
+      _trackTap(target);
+    } catch (error, stackTrace) {
+      _onTrackError(error, stackTrace);
+    }
+  }
+
+  /// Walks the element tree along [position] and returns the deepest
+  /// interactive element hit, preferring concrete controls over the generic
+  /// gesture handlers they are built from.
+  Element? _findTarget(Offset position) {
+    Element? best;
+    var bestRank = 0;
+
+    void visit(Element element) {
+      final renderObject = element.renderObject;
+      if (renderObject is RenderBox) {
+        if (!renderObject.attached || !renderObject.hasSize) {
+          return;
+        }
+        if (!renderObject.size.contains(renderObject.globalToLocal(position))) {
+          return;
+        }
+      }
+      // Non-box render objects (slivers) and elements with no render object
+      // are descended into without pruning.
+      final rank = _targetRank(element.widget);
+      if (rank > 0) {
+        if (!(widget.targetFilter?.call(element.widget) ?? true)) {
+          return; // Vetoed: exclude this widget and its internals entirely.
+        }
+        if (rank >= bestRank) {
+          best = element;
+          bestRank = rank;
+        }
+      }
+      element.visitChildElements(visit);
+    }
+
+    (context as Element).visitChildElements(visit);
+    return best;
+  }
+
+  /// Ranks how specifically [w] identifies an interaction target.
+  ///
+  /// Returns 0 for non-interactive widgets. Concrete controls rank above the
+  /// generic handlers (`InkResponse`, `GestureDetector`) they are built
+  /// from, so during the deepest-wins descent a control is not displaced by
+  /// its own internals, while a deeper control nested inside another (e.g.
+  /// an `IconButton` inside a `ListTile`) still wins.
+  int _targetRank(Widget w) {
+    // Private widgets are framework/library internals (e.g. Material 3's
+    // IconButton builds a private ButtonStyleButton subclass). Reporting
+    // them would displace the public widget the developer actually wrote.
+    if (w.runtimeType.toString().startsWith('_')) {
+      return 0;
+    }
+    if (w is ButtonStyleButton) {
+      return (w.onPressed != null || w.onLongPress != null) ? 2 : 0;
+    }
+    if (w is MaterialButton) {
+      return (w.onPressed != null || w.onLongPress != null) ? 2 : 0;
+    }
+    if (w is IconButton) {
+      return w.onPressed != null ? 2 : 0;
+    }
+    if (w is FloatingActionButton) {
+      return w.onPressed != null ? 2 : 0;
+    }
+    if (w is CupertinoButton) {
+      return w.onPressed != null ? 2 : 0;
+    }
+    if (w is ListTile) {
+      return (w.onTap != null || w.onLongPress != null) ? 2 : 0;
+    }
+    if (w is CheckboxListTile) {
+      return w.onChanged != null ? 2 : 0;
+    }
+    if (w is SwitchListTile) {
+      return w.onChanged != null ? 2 : 0;
+    }
+    if (w is Checkbox) {
+      return w.onChanged != null ? 2 : 0;
+    }
+    if (w is Switch) {
+      return w.onChanged != null ? 2 : 0;
+    }
+    if (w is PopupMenuButton) {
+      return w.enabled ? 2 : 0;
+    }
+    if (w is DropdownButton) {
+      return w.onChanged != null ? 2 : 0;
+    }
+    if (w is TextField) {
+      return (w.enabled ?? true) ? 2 : 0;
+    }
+    if (w is InkResponse) {
+      // Includes InkWell.
+      return (w.onTap != null || w.onLongPress != null || w.onDoubleTap != null)
+          ? 1
+          : 0;
+    }
+    if (w is GestureDetector) {
+      return (w.onTap != null ||
+              w.onTapUp != null ||
+              w.onTapDown != null ||
+              w.onLongPress != null ||
+              w.onDoubleTap != null)
+          ? 1
+          : 0;
+    }
+    return 0;
+  }
+
+  /// Derives a human-readable label for [target]: its `Semantics` label,
+  /// `Tooltip` message, or descendant `Text` content, in that order.
+  String? _describeTarget(Element target) {
+    String? semanticsLabel;
+    String? tooltip;
+    String? text;
+    var visited = 0;
+
+    void visit(Element element) {
+      if (semanticsLabel != null || visited >= _maxLabelSearchNodes) {
+        return;
+      }
+      visited++;
+      final w = element.widget;
+      if (w is Semantics) {
+        final label = w.properties.label;
+        if (label != null && label.isNotEmpty) {
+          semanticsLabel = label;
+          return;
+        }
+      } else if (w is Tooltip) {
+        final message = w.message;
+        if (message != null && message.isNotEmpty) {
+          tooltip ??= message;
+        }
+      } else if (w is Text) {
+        final data = w.data ?? w.textSpan?.toPlainText();
+        if (data != null && data.isNotEmpty) {
+          text ??= data;
+        }
+      } else if (w is RichText) {
+        final data = w.text.toPlainText();
+        if (data.isNotEmpty) {
+          text ??= data;
+        }
+      } else if (w is Icon) {
+        final label = w.semanticLabel;
+        if (label != null && label.isNotEmpty) {
+          tooltip ??= label;
+        }
+      }
+      element.visitChildElements(visit);
+    }
+
+    visit(target);
+    final label = semanticsLabel ?? tooltip ?? text;
+    if (label == null) {
+      return null;
+    }
+    final normalized = label.trim();
+    if (normalized.isEmpty) {
+      return null;
+    }
+    return normalized.length > _maxTargetTextLength
+        ? normalized.substring(0, _maxTargetTextLength)
+        : normalized;
+  }
+
+  /// Collects up to [_maxHierarchyDepth] non-private widget types from
+  /// [target] upward, target first.
+  List<String> _hierarchy(Element target) {
+    final names = <String>[];
+    void add(Widget w) {
+      final name = w.runtimeType.toString();
+      if (!name.startsWith('_')) {
+        names.add(name);
+      }
+    }
+
+    add(target.widget);
+    target.visitAncestorElements((element) {
+      if (names.length >= _maxHierarchyDepth) {
+        return false;
+      }
+      add(element.widget);
+      return true;
+    });
+    return names;
+  }
+
+  void _trackTap(Element target) {
+    final targetWidget = target.widget;
+    final targetText = _describeTarget(target);
+    final key = targetWidget.key;
+    final resource = key is ValueKey ? key.value?.toString() : null;
+    final screenName = widget.screenNameProvider?.call();
+
+    final properties = <String, Object?>{
+      elementActionProperty: 'touch',
+      elementTargetClassProperty: targetWidget.runtimeType.toString(),
+      if (targetText != null) elementTargetTextProperty: targetText,
+      if (resource != null && resource.isNotEmpty)
+        elementTargetResourceProperty: resource,
+      elementTargetSourceProperty: 'Flutter',
+      elementHierarchyProperty: _hierarchy(target),
+      if (screenName != null && screenName.isNotEmpty)
+        screenNameProperty: screenName,
+      ...?widget.propertiesProvider?.call(),
+    };
+
+    unawaited(
+      widget.amplitude
+          .track(BaseEvent(
+            elementInteractedEventType,
+            eventProperties: properties,
+          ))
+          .catchError(_onTrackError),
+    );
+  }
+
+  void _onTrackError(Object error, StackTrace stackTrace) {
+    assert(() {
+      debugPrint('AmplitudeElementTapDetector: failed to track '
+          '$elementInteractedEventType: $error');
+      return true;
+    }());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: _onPointerDown,
+      onPointerUp: _onPointerUp,
+      onPointerCancel: _onPointerCancel,
+      child: widget.child,
+    );
+  }
+}

--- a/lib/observers/amplitude_element_tap_detector.dart
+++ b/lib/observers/amplitude_element_tap_detector.dart
@@ -82,7 +82,9 @@ String? defaultScreenNameProvider() =>
 /// position and reports the deepest interactive widget hit. Concrete
 /// controls (buttons, tiles, toggles) take precedence over the generic
 /// gesture handlers they are built from, so an `ElevatedButton` is reported
-/// as `ElevatedButton`, not as its internal `InkWell`.
+/// as `ElevatedButton`, not as its internal `InkWell`. Mounted-but-hidden
+/// subtrees (`Offstage`, invisible `Visibility`, and therefore the inactive
+/// children of a keep-alive `IndexedStack`) are never reported.
 ///
 /// Reported properties:
 /// * `[Amplitude] Action` — always `touch`.
@@ -199,6 +201,19 @@ class _AmplitudeElementTapDetectorState
     var bestRank = 0;
 
     void visit(Element element) {
+      // Mounted-but-hidden subtrees keep real geometry but are not painted,
+      // so they must never claim a tap over the visible widget the user
+      // actually saw. This covers keep-alive tab bodies — IndexedStack wraps
+      // inactive children in Visibility.maintain(visible: false) and its
+      // render object hit-tests only the active child — and Offstage widgets
+      // (which keep their incoming size under tight constraints).
+      final w = element.widget;
+      if (w is Visibility && !w.visible) {
+        return;
+      }
+      if (w is Offstage && w.offstage) {
+        return;
+      }
       final renderObject = element.renderObject;
       if (renderObject is RenderBox) {
         if (!renderObject.attached || !renderObject.hasSize) {
@@ -210,9 +225,9 @@ class _AmplitudeElementTapDetectorState
       }
       // Non-box render objects (slivers) and elements with no render object
       // are descended into without pruning.
-      final rank = _targetRank(element.widget);
+      final rank = _targetRank(w);
       if (rank > 0) {
-        if (!(widget.targetFilter?.call(element.widget) ?? true)) {
+        if (!(widget.targetFilter?.call(w) ?? true)) {
           return; // Vetoed: exclude this widget and its internals entirely.
         }
         if (rank >= bestRank) {

--- a/lib/observers/amplitude_element_tap_detector.dart
+++ b/lib/observers/amplitude_element_tap_detector.dart
@@ -82,7 +82,9 @@ String? defaultScreenNameProvider() =>
 /// position and reports the deepest interactive widget hit. Concrete
 /// controls (buttons, tiles, toggles) take precedence over the generic
 /// gesture handlers they are built from, so an `ElevatedButton` is reported
-/// as `ElevatedButton`, not as its internal `InkWell`. Only widgets on
+/// as `ElevatedButton`, not as its internal `InkWell`, and a
+/// `CheckboxListTile` is reported as itself, not as the `ListTile` or
+/// `Checkbox` it is built from. Only widgets on
 /// Flutter's own hit-test path for the tap are eligible: widgets occluded
 /// by a dialog's barrier, inside an `IgnorePointer` or `AbsorbPointer`, and
 /// mounted-but-hidden subtrees (`Offstage`, invisible `Visibility`, and
@@ -279,9 +281,11 @@ class _AmplitudeElementTapDetectorState
   ///
   /// Returns 0 for non-interactive widgets. Concrete controls rank above the
   /// generic handlers (`InkResponse`, `GestureDetector`) they are built
-  /// from, so during the deepest-wins descent a control is not displaced by
-  /// its own internals, while a deeper control nested inside another (e.g.
-  /// an `IconButton` inside a `ListTile`) still wins.
+  /// from, and composite controls that build other public controls rank
+  /// above those (`CheckboxListTile` builds a `ListTile` and a `Checkbox`),
+  /// so during the deepest-wins descent a control is not displaced by its
+  /// own internals, while a deeper control nested inside another (e.g. an
+  /// `IconButton` inside a `ListTile`) still wins.
   int _targetRank(Widget w) {
     // Private widgets are framework/library internals (e.g. Material 3's
     // IconButton builds a private ButtonStyleButton subclass). Reporting
@@ -308,10 +312,10 @@ class _AmplitudeElementTapDetectorState
       return (w.onTap != null || w.onLongPress != null) ? 2 : 0;
     }
     if (w is CheckboxListTile) {
-      return w.onChanged != null ? 2 : 0;
+      return w.onChanged != null ? 3 : 0;
     }
     if (w is SwitchListTile) {
-      return w.onChanged != null ? 2 : 0;
+      return w.onChanged != null ? 3 : 0;
     }
     if (w is Checkbox) {
       return w.onChanged != null ? 2 : 0;

--- a/lib/observers/amplitude_element_tap_detector.dart
+++ b/lib/observers/amplitude_element_tap_detector.dart
@@ -82,9 +82,12 @@ String? defaultScreenNameProvider() =>
 /// position and reports the deepest interactive widget hit. Concrete
 /// controls (buttons, tiles, toggles) take precedence over the generic
 /// gesture handlers they are built from, so an `ElevatedButton` is reported
-/// as `ElevatedButton`, not as its internal `InkWell`. Mounted-but-hidden
-/// subtrees (`Offstage`, invisible `Visibility`, and therefore the inactive
-/// children of a keep-alive `IndexedStack`) are never reported.
+/// as `ElevatedButton`, not as its internal `InkWell`. Only widgets on
+/// Flutter's own hit-test path for the tap are eligible: widgets occluded
+/// by a dialog's barrier, inside an `IgnorePointer` or `AbsorbPointer`, and
+/// mounted-but-hidden subtrees (`Offstage`, invisible `Visibility`, and
+/// therefore the inactive children of a keep-alive `IndexedStack`) are
+/// never reported.
 ///
 /// Reported properties:
 /// * `[Amplitude] Action` — always `touch`.
@@ -183,7 +186,7 @@ class _AmplitudeElementTapDetectorState
     // resolving or tracking the target is swallowed and surfaced only in
     // debug builds.
     try {
-      final target = _findTarget(event.position);
+      final target = _findTarget(event.position, _hitPath(event));
       if (target == null) {
         return;
       }
@@ -193,20 +196,34 @@ class _AmplitudeElementTapDetectorState
     }
   }
 
+  /// The render objects Flutter's own hit test visits for [event]'s
+  /// position: the ground truth for which widgets could have received the
+  /// tap. Overlays (a dialog's barrier), [IgnorePointer], [AbsorbPointer],
+  /// and hidden subtrees (an inactive [IndexedStack] child, [Offstage]) all
+  /// keep their contents off this path.
+  Set<RenderObject> _hitPath(PointerUpEvent event) {
+    final result = HitTestResult();
+    WidgetsBinding.instance.hitTestInView(result, event.position, event.viewId);
+    return result.path
+        .map((entry) => entry.target)
+        .whereType<RenderObject>()
+        .toSet();
+  }
+
   /// Walks the element tree along [position] and returns the deepest
   /// interactive element hit, preferring concrete controls over the generic
-  /// gesture handlers they are built from.
-  Element? _findTarget(Offset position) {
+  /// gesture handlers they are built from. Only elements whose render
+  /// object is on [hitPath] are eligible, so a widget that could not have
+  /// received the tap (occluded, ignored, or hidden) is never reported.
+  Element? _findTarget(Offset position, Set<RenderObject> hitPath) {
     Element? best;
     var bestRank = 0;
 
     void visit(Element element) {
-      // Mounted-but-hidden subtrees keep real geometry but are not painted,
-      // so they must never claim a tap over the visible widget the user
-      // actually saw. This covers keep-alive tab bodies — IndexedStack wraps
-      // inactive children in Visibility.maintain(visible: false) and its
-      // render object hit-tests only the active child — and Offstage widgets
-      // (which keep their incoming size under tight constraints).
+      // Cheap traversal prunes. Mounted-but-hidden subtrees keep real
+      // geometry, so skipping them here avoids descending into subtrees
+      // (inactive keep-alive tab bodies, Offstage widgets) that the hit-path
+      // check below would reject candidate by candidate anyway.
       final w = element.widget;
       if (w is Visibility && !w.visible) {
         return;
@@ -230,7 +247,12 @@ class _AmplitudeElementTapDetectorState
         if (!(widget.targetFilter?.call(w) ?? true)) {
           return; // Vetoed: exclude this widget and its internals entirely.
         }
-        if (rank >= bestRank) {
+        // A candidate must lie on the tap's hit-test path: a widget whose
+        // geometry contains the position can still be occluded (under a
+        // dialog's ModalBarrier) or unreachable (inside IgnorePointer or
+        // AbsorbPointer), and Flutter's hit test is the ground truth for
+        // which widgets the tap could actually reach.
+        if (rank >= bestRank && _isOnHitPath(element, hitPath)) {
           best = element;
           bestRank = rank;
         }
@@ -240,6 +262,14 @@ class _AmplitudeElementTapDetectorState
 
     (context as Element).visitChildElements(visit);
     return best;
+  }
+
+  /// Whether [element] was reachable by this tap according to Flutter's hit
+  /// test. Component widgets (buttons, tiles) have no render object of
+  /// their own; their nearest descendant render object stands in for them.
+  bool _isOnHitPath(Element element, Set<RenderObject> hitPath) {
+    final renderObject = element.renderObject;
+    return renderObject != null && hitPath.contains(renderObject);
   }
 
   /// Ranks how specifically [w] identifies an interaction target.

--- a/lib/observers/amplitude_element_tap_detector.dart
+++ b/lib/observers/amplitude_element_tap_detector.dart
@@ -93,7 +93,9 @@ String? defaultScreenNameProvider() =>
 /// * `[Amplitude] Action` — always `touch`.
 /// * `[Amplitude] Target Class` — the widget's runtime type.
 /// * `[Amplitude] Target Text` — the widget's `Semantics` label, `Tooltip`
-///   message, or descendant `Text` content (first available, in that order).
+///   message, or descendant `Text` content (first available, in that
+///   order), ignoring nested interactive widgets the tap did not pass
+///   through.
 /// * `[Amplitude] Target Resource` — the widget's [ValueKey] value, if any.
 /// * `[Amplitude] Hierarchy` — up to 10 non-private ancestor widget types.
 /// * `[Amplitude] Screen Name` — from [screenNameProvider]; by default the
@@ -186,11 +188,12 @@ class _AmplitudeElementTapDetectorState
     // resolving or tracking the target is swallowed and surfaced only in
     // debug builds.
     try {
-      final target = _findTarget(event.position, _hitPath(event));
+      final hitPath = _hitPath(event);
+      final target = _findTarget(event.position, hitPath);
       if (target == null) {
         return;
       }
-      _trackTap(target);
+      _trackTap(target, hitPath);
     } catch (error, stackTrace) {
       _onTrackError(error, stackTrace);
     }
@@ -345,7 +348,13 @@ class _AmplitudeElementTapDetectorState
 
   /// Derives a human-readable label for [target]: its `Semantics` label,
   /// `Tooltip` message, or descendant `Text` content, in that order.
-  String? _describeTarget(Element target) {
+  ///
+  /// Nested interactive widgets the tap did not pass through are excluded:
+  /// they are tap targets in their own right, so their labels (a trailing
+  /// `IconButton`'s tooltip inside a `ListTile`, say) describe them and not
+  /// [target]. The target's own internals stay included, because the render
+  /// objects a tap travels through are always on [hitPath].
+  String? _describeTarget(Element target, Set<RenderObject> hitPath) {
     String? semanticsLabel;
     String? tooltip;
     String? text;
@@ -357,6 +366,11 @@ class _AmplitudeElementTapDetectorState
       }
       visited++;
       final w = element.widget;
+      if (!identical(element, target) &&
+          _targetRank(w) > 0 &&
+          !_isOnHitPath(element, hitPath)) {
+        return;
+      }
       if (w is Semantics) {
         final label = w.properties.label;
         if (label != null && label.isNotEmpty) {
@@ -423,9 +437,9 @@ class _AmplitudeElementTapDetectorState
     return names;
   }
 
-  void _trackTap(Element target) {
+  void _trackTap(Element target, Set<RenderObject> hitPath) {
     final targetWidget = target.widget;
-    final targetText = _describeTarget(target);
+    final targetText = _describeTarget(target, hitPath);
     final key = targetWidget.key;
     final resource = key is ValueKey ? key.value?.toString() : null;
     final screenName = widget.screenNameProvider?.call();

--- a/lib/observers/amplitude_navigator_observer.dart
+++ b/lib/observers/amplitude_navigator_observer.dart
@@ -85,6 +85,14 @@ class AmplitudeNavigatorObserver extends NavigatorObserver {
   /// Decides whether a route should be tracked as a screen.
   final bool Function(Route<dynamic>? route) routeFilter;
 
+  /// The name of the most recent screen view tracked by any
+  /// [AmplitudeNavigatorObserver], or `null` before the first one.
+  ///
+  /// Other autocapture sources (e.g. `AmplitudeElementTapDetector`) read this
+  /// to attach screen context to their events. Apps not using this observer
+  /// can ignore it and supply screen names to those sources directly.
+  static String? currentScreenName;
+
   /// Whether screen view autocapture is enabled on [amplitude]'s configuration.
   bool get _enabled {
     return switch (amplitude.configuration.autocapture) {
@@ -114,6 +122,7 @@ class AmplitudeNavigatorObserver extends NavigatorObserver {
         }());
         return;
       }
+      currentScreenName = name;
       unawaited(
         amplitude
             .track(BaseEvent(

--- a/test/observers/amplitude_element_tap_detector_test.dart
+++ b/test/observers/amplitude_element_tap_detector_test.dart
@@ -208,6 +208,101 @@ void main() {
           'save-button');
     });
 
+    testWidgets('only the active IndexedStack child is reported',
+        (tester) async {
+      // Keep-alive tabs: IndexedStack lays out ALL children at full size but
+      // paints and hit-tests only the active one. A hidden tab's button
+      // occupying the same coordinates must never claim the tap.
+      final amplitude = buildAmplitude();
+      Widget tab(String label) => Center(
+            child: SizedBox(
+              width: 200,
+              height: 80,
+              child: ElevatedButton(onPressed: () {}, child: Text(label)),
+            ),
+          );
+      await tester.pumpWidget(wrap(
+        amplitude,
+        SizedBox(
+          width: 300,
+          height: 300,
+          child: IndexedStack(index: 0, children: [tab('Tab A'), tab('Tab B')]),
+        ),
+      ));
+
+      await tester.tap(find.text('Tab A'));
+      await tester.pump();
+
+      expect(capturedEventProperties()[elementTargetTextProperty], 'Tab A');
+    });
+
+    testWidgets('switching the IndexedStack index reports the new active tab',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      Widget tab(String label) => Center(
+            child: SizedBox(
+              width: 200,
+              height: 80,
+              child: ElevatedButton(onPressed: () {}, child: Text(label)),
+            ),
+          );
+      Widget build(int index) => wrap(
+            amplitude,
+            SizedBox(
+              width: 300,
+              height: 300,
+              child: IndexedStack(
+                  index: index, children: [tab('Tab A'), tab('Tab B')]),
+            ),
+          );
+
+      await tester.pumpWidget(build(1));
+      await tester.tap(find.text('Tab B'));
+      await tester.pump();
+
+      expect(capturedEventProperties()[elementTargetTextProperty], 'Tab B');
+    });
+
+    testWidgets('an invisible Visibility.maintain subtree is not reported',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        Visibility.maintain(
+          visible: false,
+          child: ElevatedButton(onPressed: () {}, child: const Text('Ghost')),
+        ),
+      ));
+
+      await tester.tapAt(tester.getCenter(find.text('Ghost')));
+      await tester.pump();
+
+      verifyNever(mockChannel.invokeMethod('track', any));
+    });
+
+    testWidgets('an Offstage subtree is not reported', (tester) async {
+      // Under tight constraints an offstage RenderBox keeps its full size, so
+      // geometric containment alone would not prune it.
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        SizedBox(
+          width: 200,
+          height: 200,
+          child: Offstage(
+            child:
+                ElevatedButton(onPressed: () {}, child: const Text('Offstage')),
+          ),
+        ),
+      ));
+
+      await tester
+          .tapAt(tester.getCenter(find.text('Offstage', skipOffstage: false)));
+      await tester.pump();
+
+      verifyNever(mockChannel.invokeMethod('track', any));
+    });
+
     testWidgets('taps on non-interactive widgets are not tracked',
         (tester) async {
       final amplitude = buildAmplitude();

--- a/test/observers/amplitude_element_tap_detector_test.dart
+++ b/test/observers/amplitude_element_tap_detector_test.dart
@@ -1,0 +1,439 @@
+import 'package:amplitude_flutter/amplitude.dart';
+import 'package:amplitude_flutter/autocapture/autocapture.dart';
+import 'package:amplitude_flutter/configuration.dart';
+import 'package:amplitude_flutter/observers/amplitude_element_tap_detector.dart';
+import 'package:amplitude_flutter/observers/amplitude_navigator_observer.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+// Reuses the MockMethodChannel generated for amplitude_test.dart.
+import '../amplitude_test.mocks.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockMethodChannel mockChannel;
+
+  Amplitude buildAmplitude({Autocapture? autocapture}) {
+    mockChannel = MockMethodChannel();
+    when(mockChannel.invokeMethod('init', any)).thenAnswer((_) async => null);
+    when(mockChannel.invokeMethod('track', any)).thenAnswer((_) async => null);
+    return Amplitude(
+      Configuration(
+        apiKey: 'k',
+        autocapture: autocapture ?? const AutocaptureOptions(),
+      ),
+      mockChannel,
+    );
+  }
+
+  Widget wrap(
+    Amplitude amplitude,
+    Widget child, {
+    bool enabled = true,
+    ElementTargetFilter? targetFilter,
+    ScreenNameProvider? screenNameProvider,
+    ElementPropertiesProvider? propertiesProvider,
+  }) {
+    return AmplitudeElementTapDetector(
+      amplitude: amplitude,
+      enabled: enabled,
+      targetFilter: targetFilter,
+      screenNameProvider: screenNameProvider ?? defaultScreenNameProvider,
+      propertiesProvider: propertiesProvider,
+      child: MaterialApp(home: Scaffold(body: Center(child: child))),
+    );
+  }
+
+  Map<String, dynamic> capturedTrackEvent() {
+    final args = verify(mockChannel.invokeMethod('track', captureAny))
+        .captured
+        .single as Map;
+    return (args['event'] as Map).cast<String, dynamic>();
+  }
+
+  Map<String, dynamic> capturedEventProperties() =>
+      (capturedTrackEvent()['event_properties'] as Map).cast<String, dynamic>();
+
+  setUp(() {
+    AmplitudeNavigatorObserver.currentScreenName = null;
+  });
+
+  group('AmplitudeElementTapDetector', () {
+    testWidgets('tapping an ElevatedButton tracks an element interaction',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(onPressed: () {}, child: const Text('Save')),
+      ));
+
+      await tester.tap(find.text('Save'));
+      await tester.pump();
+
+      final event = capturedTrackEvent();
+      expect(event['event_type'], elementInteractedEventType);
+      final props = (event['event_properties'] as Map).cast<String, dynamic>();
+      expect(props[elementActionProperty], 'touch');
+      expect(props[elementTargetClassProperty], 'ElevatedButton');
+      expect(props[elementTargetTextProperty], 'Save');
+      expect(props[elementTargetSourceProperty], 'Flutter');
+      expect(props[elementHierarchyProperty], isA<List<dynamic>>());
+      expect((props[elementHierarchyProperty] as List).first, 'ElevatedButton');
+    });
+
+    testWidgets('a concrete control beats its internal gesture handlers',
+        (tester) async {
+      // ElevatedButton is built from an InkWell; the button must be reported,
+      // not its internals.
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(onPressed: () {}, child: const Text('Go')),
+      ));
+
+      await tester.tap(find.text('Go'));
+      await tester.pump();
+
+      expect(capturedEventProperties()[elementTargetClassProperty],
+          'ElevatedButton');
+    });
+
+    testWidgets('a control nested inside another control wins', (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        SizedBox(
+          width: 300,
+          child: ListTile(
+            onTap: () {},
+            title: const Text('Row title'),
+            trailing: IconButton(
+              tooltip: 'Delete row',
+              onPressed: () {},
+              icon: const Icon(Icons.delete),
+            ),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byType(IconButton));
+      await tester.pump();
+
+      final props = capturedEventProperties();
+      expect(props[elementTargetClassProperty], 'IconButton');
+      expect(props[elementTargetTextProperty], 'Delete row');
+    });
+
+    testWidgets('sibling containment: the tapped button is reported',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextButton(onPressed: () {}, child: const Text('Left')),
+            TextButton(onPressed: () {}, child: const Text('Right')),
+          ],
+        ),
+      ));
+
+      await tester.tap(find.text('Right'));
+      await tester.pump();
+
+      expect(capturedEventProperties()[elementTargetTextProperty], 'Right');
+    });
+
+    testWidgets('GestureDetector with onTap is captured', (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        GestureDetector(
+          onTap: () {},
+          child: Container(
+            width: 100,
+            height: 100,
+            color: const Color(0xFF000000),
+            child: const Text('Custom'),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('Custom'));
+      await tester.pump();
+
+      final props = capturedEventProperties();
+      expect(props[elementTargetClassProperty], 'GestureDetector');
+      expect(props[elementTargetTextProperty], 'Custom');
+    });
+
+    testWidgets('Semantics label wins over descendant text', (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(
+          onPressed: () {},
+          child: Semantics(
+            label: 'Submit order',
+            child: const Text('OK'),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('OK'));
+      await tester.pump();
+
+      expect(
+          capturedEventProperties()[elementTargetTextProperty], 'Submit order');
+    });
+
+    testWidgets('a ValueKey is reported as the target resource',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(
+          key: const ValueKey('save-button'),
+          onPressed: () {},
+          child: const Text('Save'),
+        ),
+      ));
+
+      await tester.tap(find.text('Save'));
+      await tester.pump();
+
+      expect(capturedEventProperties()[elementTargetResourceProperty],
+          'save-button');
+    });
+
+    testWidgets('taps on non-interactive widgets are not tracked',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(amplitude, const Text('Just text')));
+
+      await tester.tap(find.text('Just text'));
+      await tester.pump();
+
+      verifyNever(mockChannel.invokeMethod('track', any));
+    });
+
+    testWidgets('disabled buttons are not tracked', (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        const ElevatedButton(onPressed: null, child: Text('Disabled')),
+      ));
+
+      await tester.tap(find.text('Disabled'));
+      await tester.pump();
+
+      verifyNever(mockChannel.invokeMethod('track', any));
+    });
+
+    testWidgets('drags and scrolls are not tracked', (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        SizedBox(
+          height: 200,
+          child: ListView(
+            children: [
+              ListTile(onTap: () {}, title: const Text('Item 1')),
+              ListTile(onTap: () {}, title: const Text('Item 2')),
+              ListTile(onTap: () {}, title: const Text('Item 3')),
+            ],
+          ),
+        ),
+      ));
+
+      await tester.drag(find.text('Item 1'), const Offset(0, -80));
+      await tester.pump();
+
+      verifyNever(mockChannel.invokeMethod('track', any));
+    });
+
+    testWidgets('enabled: false disables capture', (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(onPressed: () {}, child: const Text('Save')),
+        enabled: false,
+      ));
+
+      await tester.tap(find.text('Save'));
+      await tester.pump();
+
+      verifyNever(mockChannel.invokeMethod('track', any));
+    });
+
+    testWidgets('targetFilter can veto a widget', (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(onPressed: () {}, child: const Text('Save')),
+        targetFilter: (widget) => widget is! ElevatedButton,
+      ));
+
+      await tester.tap(find.text('Save'));
+      await tester.pump();
+
+      verifyNever(mockChannel.invokeMethod('track', any));
+    });
+
+    testWidgets('screen name from the navigator observer is attached',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      AmplitudeNavigatorObserver.currentScreenName = '/settings';
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(onPressed: () {}, child: const Text('Save')),
+      ));
+
+      await tester.tap(find.text('Save'));
+      await tester.pump();
+
+      expect(capturedEventProperties()[screenNameProperty], '/settings');
+    });
+
+    testWidgets('custom screenNameProvider overrides the default',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(onPressed: () {}, child: const Text('Save')),
+        screenNameProvider: () => 'customScreen',
+      ));
+
+      await tester.tap(find.text('Save'));
+      await tester.pump();
+
+      expect(capturedEventProperties()[screenNameProperty], 'customScreen');
+    });
+
+    testWidgets('propertiesProvider properties are merged into the event',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(onPressed: () {}, child: const Text('Save')),
+        propertiesProvider: () => {
+          'organization_id': 'org-1',
+          'organization_name': 'Acme',
+        },
+      ));
+
+      await tester.tap(find.text('Save'));
+      await tester.pump();
+
+      final props = capturedEventProperties();
+      expect(props['organization_id'], 'org-1');
+      expect(props['organization_name'], 'Acme');
+    });
+
+    testWidgets('taps inside a dialog are captured', (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(AmplitudeElementTapDetector(
+        amplitude: amplitude,
+        child: MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Center(
+                child: ElevatedButton(
+                  onPressed: () => showDialog<void>(
+                    context: context,
+                    builder: (_) => AlertDialog(
+                      actions: [
+                        TextButton(
+                            onPressed: () {}, child: const Text('Confirm')),
+                      ],
+                    ),
+                  ),
+                  child: const Text('Open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('Open'));
+      await tester.pumpAndSettle();
+      clearInteractions(mockChannel);
+
+      await tester.tap(find.text('Confirm'));
+      await tester.pump();
+
+      final props = capturedEventProperties();
+      expect(props[elementTargetClassProperty], 'TextButton');
+      expect(props[elementTargetTextProperty], 'Confirm');
+    });
+
+    testWidgets('a failing track never breaks the tap', (tester) async {
+      final amplitude = buildAmplitude();
+      when(mockChannel.invokeMethod('track', any))
+          .thenThrow(Exception('track boom'));
+      var tapped = false;
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(
+          onPressed: () => tapped = true,
+          child: const Text('Save'),
+        ),
+      ));
+
+      await tester.tap(find.text('Save'));
+      await tester.pump();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('long target text is truncated to 128 characters',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      final longText = 'x' * 500;
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ElevatedButton(
+          onPressed: () {},
+          child: Text(longText, overflow: TextOverflow.ellipsis),
+        ),
+      ));
+
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pump();
+
+      final text =
+          capturedEventProperties()[elementTargetTextProperty] as String;
+      expect(text.length, 128);
+    });
+  });
+
+  group('AmplitudeNavigatorObserver.currentScreenName', () {
+    testWidgets('is updated as screens are tracked', (tester) async {
+      final amplitude = buildAmplitude(
+          autocapture: const AutocaptureOptions(screenViews: true));
+      final observer = AmplitudeNavigatorObserver(amplitude);
+
+      await tester.pumpWidget(MaterialApp(
+        navigatorObservers: [observer],
+        routes: {
+          '/': (context) => Scaffold(
+                body: ElevatedButton(
+                  onPressed: () => Navigator.of(context).pushNamed('/details'),
+                  child: const Text('Go'),
+                ),
+              ),
+          '/details': (context) => const Scaffold(body: Text('Details')),
+        },
+      ));
+      await tester.pumpAndSettle();
+      expect(AmplitudeNavigatorObserver.currentScreenName, '/');
+
+      await tester.tap(find.text('Go'));
+      await tester.pumpAndSettle();
+      expect(AmplitudeNavigatorObserver.currentScreenName, '/details');
+    });
+  });
+}

--- a/test/observers/amplitude_element_tap_detector_test.dart
+++ b/test/observers/amplitude_element_tap_detector_test.dart
@@ -303,6 +303,75 @@ void main() {
       verifyNever(mockChannel.invokeMethod('track', any));
     });
 
+    testWidgets('a widget behind a dialog barrier is not reported',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(AmplitudeElementTapDetector(
+        amplitude: amplitude,
+        child: MaterialApp(
+          home: Scaffold(
+            body: Builder(
+              builder: (context) => Align(
+                alignment: Alignment.bottomCenter,
+                child: ElevatedButton(
+                  onPressed: () => showDialog<void>(
+                    context: context,
+                    builder: (_) => const AlertDialog(title: Text('Dialog')),
+                  ),
+                  child: const Text('Covered'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ));
+
+      final buttonCenter = tester.getCenter(find.text('Covered'));
+      await tester.tapAt(buttonCenter);
+      await tester.pumpAndSettle();
+      clearInteractions(mockChannel);
+
+      // The dialog's barrier now covers the button. Its geometry still
+      // contains the tap position, but the tap can only reach the barrier.
+      await tester.tapAt(buttonCenter);
+      await tester.pump();
+
+      verifyNever(mockChannel.invokeMethod('track', any));
+    });
+
+    testWidgets('a button inside IgnorePointer is not reported',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        IgnorePointer(
+          child: ElevatedButton(onPressed: () {}, child: const Text('Ignored')),
+        ),
+      ));
+
+      await tester.tapAt(tester.getCenter(find.text('Ignored')));
+      await tester.pump();
+
+      verifyNever(mockChannel.invokeMethod('track', any));
+    });
+
+    testWidgets('a button inside AbsorbPointer is not reported',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        AbsorbPointer(
+          child:
+              ElevatedButton(onPressed: () {}, child: const Text('Absorbed')),
+        ),
+      ));
+
+      await tester.tapAt(tester.getCenter(find.text('Absorbed')));
+      await tester.pump();
+
+      verifyNever(mockChannel.invokeMethod('track', any));
+    });
+
     testWidgets('taps on non-interactive widgets are not tracked',
         (tester) async {
       final amplitude = buildAmplitude();

--- a/test/observers/amplitude_element_tap_detector_test.dart
+++ b/test/observers/amplitude_element_tap_detector_test.dart
@@ -126,6 +126,66 @@ void main() {
       expect(props[elementTargetTextProperty], 'Delete row');
     });
 
+    testWidgets('a CheckboxListTile is reported, not its internals',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        CheckboxListTile(
+          value: false,
+          onChanged: (_) {},
+          title: const Text('Enable Wi-Fi'),
+        ),
+      ));
+
+      await tester.tap(find.text('Enable Wi-Fi'));
+      await tester.pump();
+
+      final props = capturedEventProperties();
+      expect(props[elementTargetClassProperty], 'CheckboxListTile');
+      expect(props[elementTargetTextProperty], 'Enable Wi-Fi');
+    });
+
+    testWidgets('tapping the checkbox itself reports the CheckboxListTile',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        CheckboxListTile(
+          value: false,
+          onChanged: (_) {},
+          title: const Text('Enable Wi-Fi'),
+        ),
+      ));
+
+      await tester.tap(find.byType(Checkbox));
+      await tester.pump();
+
+      final props = capturedEventProperties();
+      expect(props[elementTargetClassProperty], 'CheckboxListTile');
+      expect(props[elementTargetTextProperty], 'Enable Wi-Fi');
+    });
+
+    testWidgets('a SwitchListTile is reported, not its internals',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        SwitchListTile(
+          value: false,
+          onChanged: (_) {},
+          title: const Text('Dark mode'),
+        ),
+      ));
+
+      await tester.tap(find.byType(Switch));
+      await tester.pump();
+
+      final props = capturedEventProperties();
+      expect(props[elementTargetClassProperty], 'SwitchListTile');
+      expect(props[elementTargetTextProperty], 'Dark mode');
+    });
+
     testWidgets('sibling containment: the tapped button is reported',
         (tester) async {
       final amplitude = buildAmplitude();

--- a/test/observers/amplitude_element_tap_detector_test.dart
+++ b/test/observers/amplitude_element_tap_detector_test.dart
@@ -189,6 +189,54 @@ void main() {
           capturedEventProperties()[elementTargetTextProperty], 'Submit order');
     });
 
+    testWidgets("a nested control's label does not become the target text",
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ListTile(
+          onTap: () {},
+          title: const Text('Wi-Fi'),
+          trailing: IconButton(
+            onPressed: () {},
+            tooltip: 'Delete',
+            icon: const Icon(Icons.delete),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.text('Wi-Fi'));
+      await tester.pump();
+
+      final props = capturedEventProperties();
+      expect(props[elementTargetClassProperty], 'ListTile');
+      expect(props[elementTargetTextProperty], 'Wi-Fi');
+    });
+
+    testWidgets('tapping the nested control itself reports its own label',
+        (tester) async {
+      final amplitude = buildAmplitude();
+      await tester.pumpWidget(wrap(
+        amplitude,
+        ListTile(
+          onTap: () {},
+          title: const Text('Wi-Fi'),
+          trailing: IconButton(
+            onPressed: () {},
+            tooltip: 'Delete',
+            icon: const Icon(Icons.delete),
+          ),
+        ),
+      ));
+
+      await tester.tap(find.byIcon(Icons.delete));
+      await tester.pump();
+
+      final props = capturedEventProperties();
+      expect(props[elementTargetClassProperty], 'IconButton');
+      expect(props[elementTargetTextProperty], 'Delete');
+    });
+
     testWidgets('a ValueKey is reported as the target resource',
         (tester) async {
       final amplitude = buildAmplitude();


### PR DESCRIPTION
## Summary

Adds `AmplitudeElementTapDetector`, an opt-in widget that autocaptures taps on interactive Flutter widgets as `[Amplitude] Element Interacted` events on every platform (iOS, Android, web), without requiring the app to enable Flutter's semantics tree.

This is a follow-up to #309, which shipped screen view autocapture and web autocapture. It covers the one interaction the SDK still cannot see: taps on Flutter widgets themselves.

## Why the SDK cannot already capture widget taps

- The native iOS/Android SDKs' element interaction autocapture sees a single `FlutterActivity` / `FlutterViewController`, because Flutter renders every widget itself into one native view.
- The Browser SDK's DOM capture (`AutocaptureOptions.elementInteractions`) only sees `<flt-semantics>` nodes, and only when the app enables the semantics tree globally, which the docs added in #309 advise against. With semantics off it sees only the framework's canvas host elements.

Neither path can name a Flutter widget. This widget closes that gap in Dart, so tap capture works with semantics off.

## How it works

Wrap the app root:

```dart
runApp(AmplitudeElementTapDetector(
  amplitude: amplitude,
  child: const MyApp(),
));
```

- A translucent `Listener` observes pointer events; a tap is a primary-button down and up within `kTouchSlop`.
- On pointer-up it walks the element tree along the tap position and reports the deepest interactive widget hit, ranked so concrete controls beat the generic handlers they are built from (an `ElevatedButton` is reported as `ElevatedButton`, not as its internal `InkWell`).
- Private framework widgets (`_`-prefixed types) are never reported.
- Mounted-but-hidden subtrees are never reported: `Offstage`, invisible `Visibility`, and therefore the inactive children of a keep-alive `IndexedStack`.

## Event properties

Property names deliberately match the mobile element interaction taxonomy (verified against the current `Amplitude-Kotlin` constants), so events unify with iOS/Android in the Amplitude UI:

| Property | Value |
|---|---|
| `[Amplitude] Action` | always `touch` |
| `[Amplitude] Target Class` | the widget's runtime type |
| `[Amplitude] Target Text` | `Semantics` label, `Tooltip` message, or descendant `Text` content (first available, capped at 128 chars) |
| `[Amplitude] Target Resource` | the widget's `ValueKey` value, if any |
| `[Amplitude] Hierarchy` | up to 10 non-private ancestor widget types |
| `[Amplitude] Screen Name` | from `screenNameProvider`; by default the last screen tracked by `AmplitudeNavigatorObserver` |
| `[Amplitude] Target Source` | `Flutter` |

## Safety properties

Analytics must never interfere with the app:

- All capture work runs after pointer-up; nothing blocks or alters gesture handling.
- Every internal failure is swallowed and surfaced only as a debug-mode log.
- All traversal is bounded: at most 10 hierarchy entries, at most 256 nodes visited when deriving a label, target text capped at 128 chars, and the pointer-tracking map is capped.

## Production mileage

This exact code has been running in the Arcade AI Flutter app (iOS, Android, and web) since mid-July 2026 via our fork, capturing element interaction events for every tap in the app across all three platforms.

## Backwards compatibility

Purely additive: one new file, one new opt-in widget, and one new static on `AmplitudeNavigatorObserver`. No existing default changes, and nothing new fires unless the app wraps its root.

One caveat, documented in the dartdoc: on web, an app that enables both this widget and the Browser SDK's DOM `elementInteractions` capture may get two events per tap.

## Open API questions

Two design choices we would like your call on; adopting either alternative is a small follow-up commit, not a rewrite.

1. **Gating.** As proposed, capture is gated by constructing the widget plus its `enabled` flag, and is deliberately independent of `AutocaptureOptions.elementInteractions`: that option configures the Browser SDK's DOM capture, and coupling them would double-count taps on web. The alternative would be a Dart-only `AutocaptureOptions.widgetInteractions` flag, default off, excluded from `toMap()` so native plugins never see an unknown key, mirroring how `screenViews` plus attaching the observer are both required for screen views.
2. **`AmplitudeNavigatorObserver.currentScreenName`.** Proposed as a public mutable static: it is the simplest way for the detector to stamp `[Amplitude] Screen Name`, and it lets tests and apps that do not use the observer set it directly. If you prefer a tighter surface we can make it a read-only getter with an `@internal` setter; `screenNameProvider` is already constructor-injectable, so the static is only the default.

## Testing

- `flutter analyze` clean; `flutter test` and `flutter test --platform chrome` both pass (the detector suite reuses the existing `test/amplitude_test.mocks.dart`, no build_runner regeneration needed).
- `example/lib/my_app.dart` is updated to wrap its root, so `flutter run` in the example app shows `[Amplitude] Element Interacted` in debug logs when tapping around.

Since #315 keeps autocapture documentation out of the README, usage documentation lives in the dartdoc on `AmplitudeElementTapDetector` and in the example app. Happy to also draft a docs-site snippet for amplitude.com if you would like this documented there.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New global pointer listener and analytics on every tap could affect performance or event volume in production apps; capture is designed to be non-blocking and opt-in only.
> 
> **Overview**
> Adds opt-in **`AmplitudeElementTapDetector`**, which wraps the app and emits **`[Amplitude] Element Interacted`** events for qualifying widget taps on iOS, Android, and web **without** enabling Flutter’s semantics tree. Resolution uses hit-testing and element-tree walks so concrete controls win over internal `InkWell`/`GestureDetector` handlers, and occluded, hidden, or non-interactive targets are skipped.
> 
> **`AmplitudeNavigatorObserver`** now maintains **`currentScreenName`** so element events can include **`[Amplitude] Screen Name`** (overridable via `screenNameProvider`).
> 
> The **example app** wraps its root with the detector and **drops** Browser SDK **`elementInteractions`** autocapture to avoid duplicate taps on web; web **`main()`** comments now say semantics are only needed for form capture, not element taps.
> 
> A large **widget test suite** covers target ranking, filters, screen context, and failure isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a05e71683c4e6a30304d1219dad08d0b1e50d4fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->